### PR TITLE
feat: add configurable LOG_LEVEL environment variable

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,3 +1,7 @@
+# Logging Configuration
+# Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)
+LOG_LEVEL=INFO
+
 # Pulsar Configuration
 PULSAR_SERVICE_URL=pulsar://localhost:6650
 PULSAR_TOPIC=persistent://streamhub/v1/frames

--- a/src/stream_processor/utils/logger.py
+++ b/src/stream_processor/utils/logger.py
@@ -11,7 +11,7 @@ import structlog
 
 def get_log_level() -> int:
     """Get log level from LOG_LEVEL environment variable.
-    
+
     Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
     Default: INFO
     """

--- a/src/stream_processor/utils/logger.py
+++ b/src/stream_processor/utils/logger.py
@@ -3,19 +3,31 @@ Structured logging configuration using structlog.
 """
 
 import logging
+import os
 import sys
 
 import structlog
 
 
+def get_log_level() -> int:
+    """Get log level from LOG_LEVEL environment variable.
+    
+    Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL
+    Default: INFO
+    """
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    return getattr(logging, level_name, logging.INFO)
+
+
 def configure_logging() -> None:
     """Configure structlog with console output."""
+    log_level = get_log_level()
 
     # Configure standard logging
     logging.basicConfig(
         format="%(message)s",
         stream=sys.stdout,
-        level=logging.INFO,
+        level=log_level,
     )
 
     # Configure structlog
@@ -28,7 +40,7 @@ def configure_logging() -> None:
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.dev.ConsoleRenderer(colors=True),
         ],
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.make_filtering_bound_logger(log_level),
         context_class=dict,
         logger_factory=structlog.PrintLoggerFactory(),
         cache_logger_on_first_use=True,


### PR DESCRIPTION
Add support for controlling logging verbosity via LOG_LEVEL env var. This reduces log volume in production when set to WARNING or ERROR.

Valid values: DEBUG, INFO (default), WARNING, ERROR, CRITICAL

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable logging level via the LOG_LEVEL environment variable (defaults to INFO) to control application output verbosity.
  * Updated environment example and documentation to list valid log level values for easier configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->