### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alterna…

### DIFF
--- a/src/stream_processor/service/cleanup_service.py
+++ b/src/stream_processor/service/cleanup_service.py
@@ -7,7 +7,7 @@ Supports both filesystem and GCS storage backends.
 
 import asyncio
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from ..config.settings import settings
 from ..utils.logger import get_logger
@@ -92,7 +92,7 @@ class CleanupService:
         start_time = time.time()
 
         # Calculate cutoff time
-        cutoff_time = datetime.now(datetime.UTC) - timedelta(hours=self.retention_hours)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=self.retention_hours)  # noqa: UP017
         cutoff_timestamp = cutoff_time.timestamp()
 
         total_deleted = 0

--- a/src/stream_processor/service/cleanup_service.py
+++ b/src/stream_processor/service/cleanup_service.py
@@ -7,7 +7,7 @@ Supports both filesystem and GCS storage backends.
 
 import asyncio
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from ..config.settings import settings
 from ..utils.logger import get_logger
@@ -92,7 +92,7 @@ class CleanupService:
         start_time = time.time()
 
         # Calculate cutoff time
-        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=self.retention_hours)
+        cutoff_time = datetime.now(datetime.UTC) - timedelta(hours=self.retention_hours)
         cutoff_timestamp = cutoff_time.timestamp()
 
         total_deleted = 0

--- a/src/stream_processor/service/cleanup_service.py
+++ b/src/stream_processor/service/cleanup_service.py
@@ -7,7 +7,7 @@ Supports both filesystem and GCS storage backends.
 
 import asyncio
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from ..config.settings import settings
 from ..utils.logger import get_logger
@@ -92,7 +92,7 @@ class CleanupService:
         start_time = time.time()
 
         # Calculate cutoff time
-        cutoff_time = datetime.utcnow() - timedelta(hours=self.retention_hours)
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=self.retention_hours)
         cutoff_timestamp = cutoff_time.timestamp()
 
         total_deleted = 0


### PR DESCRIPTION
…tive

Use datetime.now(timezone.utc) instead of the deprecated utcnow() method to get timezone-aware datetime objects as recommended in Python 3.12+.

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved time handling in the cleanup service to use explicit UTC-aware timestamps, making deletion checks and timestamp processing more robust and consistent across timezones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->