### PR TITLE
feat: add timezone support to watermark timestamps

### DIFF
--- a/src/stream_processor/config/settings.py
+++ b/src/stream_processor/config/settings.py
@@ -112,6 +112,13 @@ class WatermarkConfig(BaseSettings):
     format: str = Field(
         default="%Y-%m-%d %H:%M:%S.%f", description="Python strftime format string for timestamp"
     )
+    timezone: str | None = Field(
+        default=None,
+        description="IANA timezone name (e.g., America/Santiago, UTC). If None, uses UTC.",
+    )
+    show_timezone: bool = Field(
+        default=True, description="Show timezone offset and name in watermark"
+    )
 
 
 class Settings(BaseSettings):

--- a/src/stream_processor/service/watermark_service.py
+++ b/src/stream_processor/service/watermark_service.py
@@ -64,14 +64,17 @@ class WatermarkService:
 
     def _format_timestamp(self, timestamp: datetime) -> str:
         """Format timestamp according to configuration with timezone support."""
-        import re
         from zoneinfo import ZoneInfo
+
+        # Track the effective timezone name for display
+        effective_tz_name = None
 
         # Convert to configured timezone if specified
         if self.config.timezone:
             try:
                 tz = ZoneInfo(self.config.timezone)
                 timestamp = timestamp.astimezone(tz)
+                effective_tz_name = self.config.timezone
             except Exception as e:
                 # Fall back to UTC if timezone is invalid
                 from ..utils.logger import get_logger
@@ -79,20 +82,25 @@ class WatermarkService:
                 logger = get_logger(__name__)
                 logger.warning(f"Invalid timezone '{self.config.timezone}': {e}. Using UTC.")
                 timestamp = timestamp.astimezone(ZoneInfo("UTC"))
+                effective_tz_name = "UTC"
         else:
             # Default to UTC if no timezone configured
             from zoneinfo import ZoneInfo
 
             timestamp = timestamp.astimezone(ZoneInfo("UTC"))
+            effective_tz_name = "UTC"
 
         # Format the timestamp
         formatted = timestamp.strftime(self.config.format)
 
         # Truncate microseconds to milliseconds for display
         if "%f" in self.config.format:
-            # Replace the 6-digit microsecond with 3-digit millisecond
-            # Matches 6 consecutive digits (microseconds) and replaces with first 3 digits
-            formatted = re.sub(r"(\d{3})\d{3}", r"\1", formatted, count=1)
+            # Get the actual microsecond value from the timestamp
+            microsecond = timestamp.microsecond
+            millisecond = microsecond // 1000
+            # Replace the 6-digit microsecond string with 3-digit millisecond
+            # This avoids accidentally matching other digit sequences like YYYYMMDD
+            formatted = formatted.replace(f"{microsecond:06d}", f"{millisecond:03d}", 1)
 
         # Add timezone information if enabled
         if self.config.show_timezone:
@@ -104,8 +112,8 @@ class WatermarkService:
             else:
                 offset_formatted = "+00:00"
 
-            # Get timezone name
-            tz_name = self.config.timezone or "UTC"
+            # Use the effective timezone name (matches the actual timezone used)
+            tz_name = effective_tz_name or "UTC"
 
             # Append timezone info: "YYYY-MM-DD HH:MM:SS.sss -03:00 [America/Santiago]"
             formatted = f"{formatted} {offset_formatted} [{tz_name}]"

--- a/src/stream_processor/service/watermark_service.py
+++ b/src/stream_processor/service/watermark_service.py
@@ -63,15 +63,53 @@ class WatermarkService:
         return position_map.get(self.config.position, position_map["top_right"])
 
     def _format_timestamp(self, timestamp: datetime) -> str:
-        """Format timestamp according to configuration."""
+        """Format timestamp according to configuration with timezone support."""
         import re
+        from zoneinfo import ZoneInfo
 
+        # Convert to configured timezone if specified
+        if self.config.timezone:
+            try:
+                tz = ZoneInfo(self.config.timezone)
+                timestamp = timestamp.astimezone(tz)
+            except Exception as e:
+                # Fall back to UTC if timezone is invalid
+                from ..utils.logger import get_logger
+
+                logger = get_logger(__name__)
+                logger.warning(f"Invalid timezone '{self.config.timezone}': {e}. Using UTC.")
+                timestamp = timestamp.astimezone(ZoneInfo("UTC"))
+        else:
+            # Default to UTC if no timezone configured
+            from zoneinfo import ZoneInfo
+
+            timestamp = timestamp.astimezone(ZoneInfo("UTC"))
+
+        # Format the timestamp
         formatted = timestamp.strftime(self.config.format)
+
         # Truncate microseconds to milliseconds for display
         if "%f" in self.config.format:
             # Replace the 6-digit microsecond with 3-digit millisecond
             # Matches 6 consecutive digits (microseconds) and replaces with first 3 digits
             formatted = re.sub(r"(\d{3})\d{3}", r"\1", formatted, count=1)
+
+        # Add timezone information if enabled
+        if self.config.show_timezone:
+            # Get UTC offset (e.g., -03:00)
+            offset = timestamp.strftime("%z")
+            # Format offset as ±HH:MM
+            if offset:
+                offset_formatted = f"{offset[:3]}:{offset[3:]}"
+            else:
+                offset_formatted = "+00:00"
+
+            # Get timezone name
+            tz_name = self.config.timezone or "UTC"
+
+            # Append timezone info: "YYYY-MM-DD HH:MM:SS.sss -03:00 [America/Santiago]"
+            formatted = f"{formatted} {offset_formatted} [{tz_name}]"
+
         return formatted
 
     async def add_timestamp_watermark(


### PR DESCRIPTION
Add configurable timezone support to watermark service with the following features:

- WATERMARK_TIMEZONE: IANA timezone name (e.g., America/Santiago, UTC)
- WATERMARK_SHOW_TIMEZONE: Toggle timezone display (default: true)
- Format: "YYYY-MM-DD HH:MM:SS.sss ±HH:MM [Timezone]"

The service automatically converts UTC timestamps to the configured timezone and displays both the offset and timezone name for clarity. Falls back to UTC if timezone is invalid or not specified.

Example output: "2026-01-15 11:30:45.123 -03:00 [America/Santiago]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watermarks can display timestamps in a specific timezone with offset and timezone name.
  * New setting to enable or disable timezone display in watermarks.

* **Bug Fixes / Improvements**
  * More accurate millisecond precision in watermark timestamps.
  * Invalid timezone configurations now fall back to UTC with a warning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->