### PR TITLE
feat: add maximum session duration to auto-break never-ending transmissions

### DIFF
--- a/src/stream_processor/config/settings.py
+++ b/src/stream_processor/config/settings.py
@@ -93,6 +93,10 @@ class ArchiveConfig(BaseSettings):
     offline_threshold_seconds: int = Field(
         default=60, description="Seconds without frames before considered offline"
     )
+    max_session_duration_seconds: int = Field(
+        default=7200,  # 2 hours
+        description="Maximum session duration before auto-breaking (0 to disable)",
+    )
     database_url: str | None = Field(
         default=None, description="PostgreSQL connection URL for archive metadata"
     )

--- a/src/stream_processor/service/offline_checker.py
+++ b/src/stream_processor/service/offline_checker.py
@@ -165,13 +165,39 @@ class OfflineChecker:
         Break a session due to max duration exceeded and start a new one.
 
         The device is still actively sending frames, so we:
-        1. Archive the current session
-        2. Create a new session that continues seamlessly
+        1. Re-read the latest session data to capture any segments that arrived since snapshot
+        2. Archive the current session
+        3. Create a new session that continues seamlessly
 
         Args:
-            session: The session data from Redis
+            session: The session data from Redis (may be stale)
         """
         state_key = session.state_key
+        original_session_id = session.session_id
+
+        # Re-read the latest session data to capture any segments that arrived
+        # between the check_once snapshot and now
+        latest_session = await self.session_store.get_session(
+            session.client_id, session.device_id
+        )
+
+        if latest_session is None:
+            logger.warning(
+                f"Session disappeared before break (max duration): {state_key} "
+                f"session={original_session_id}"
+            )
+            return
+
+        # Verify session_id hasn't changed (another process might have restarted it)
+        if latest_session.session_id != original_session_id:
+            logger.info(
+                f"Session already restarted by another process (max duration): {state_key} "
+                f"original={original_session_id}, current={latest_session.session_id}"
+            )
+            return
+
+        # Use the latest session data for archiving
+        session = latest_session
 
         # Skip archiving if no segments generated
         if session.first_segment_number < 0 or session.last_segment_number < 0:

--- a/src/stream_processor/service/offline_checker.py
+++ b/src/stream_processor/service/offline_checker.py
@@ -177,9 +177,7 @@ class OfflineChecker:
 
         # Re-read the latest session data to capture any segments that arrived
         # between the check_once snapshot and now
-        latest_session = await self.session_store.get_session(
-            session.client_id, session.device_id
-        )
+        latest_session = await self.session_store.get_session(session.client_id, session.device_id)
 
         if latest_session is None:
             logger.warning(

--- a/src/stream_processor/service/offline_checker.py
+++ b/src/stream_processor/service/offline_checker.py
@@ -56,22 +56,24 @@ class OfflineChecker:
 
     async def check_once(self) -> int:
         """
-        Check for offline devices once.
+        Check for offline devices and sessions exceeding max duration.
 
         Returns:
-            Number of offline sessions detected and processed
+            Number of sessions processed (offline + max duration exceeded)
         """
         await self.session_store.connect()
 
         now = datetime.now(UTC)
         threshold = timedelta(seconds=self.config.offline_threshold_seconds)
-        offline_count = 0
+        max_duration = self.config.max_session_duration_seconds
+        processed_count = 0
 
         sessions = await self.session_store.get_all_sessions()
 
         logger.info(
             f"[OfflineChecker] Checking {len(sessions)} active session(s), "
-            f"threshold={self.config.offline_threshold_seconds}s"
+            f"offline_threshold={self.config.offline_threshold_seconds}s, "
+            f"max_duration={max_duration}s"
         )
 
         for session in sessions:
@@ -84,6 +86,7 @@ class OfflineChecker:
                 f"segments={session.first_segment_number}-{session.last_segment_number}"
             )
 
+            # Check offline first (device stopped sending)
             if idle_time > threshold:
                 logger.info(
                     f"Device offline detected: {session.state_key} "
@@ -91,9 +94,18 @@ class OfflineChecker:
                     f"session duration={session.duration_seconds}s)"
                 )
                 await self._end_session(session)
-                offline_count += 1
+                processed_count += 1
 
-        return offline_count
+            # Check max duration (device still active but session too long)
+            elif max_duration > 0 and session.duration_seconds >= max_duration:
+                logger.info(
+                    f"Max duration exceeded: {session.state_key} "
+                    f"(duration={session.duration_seconds}s >= {max_duration}s)"
+                )
+                await self._break_session_for_duration(session)
+                processed_count += 1
+
+        return processed_count
 
     async def _end_session(self, session: SessionData) -> None:
         """
@@ -148,6 +160,66 @@ class OfflineChecker:
         except Exception as e:
             logger.error(f"Error creating archive for {state_key}: {e}", exc_info=True)
 
+    async def _break_session_for_duration(self, session: SessionData) -> None:
+        """
+        Break a session due to max duration exceeded and start a new one.
+
+        The device is still actively sending frames, so we:
+        1. Archive the current session
+        2. Create a new session that continues seamlessly
+
+        Args:
+            session: The session data from Redis
+        """
+        state_key = session.state_key
+
+        # Skip archiving if no segments generated
+        if session.first_segment_number < 0 or session.last_segment_number < 0:
+            logger.info(f"Session has no segments to archive (max duration): {state_key}")
+            await self.session_store.restart_session(session.client_id, session.device_id)
+            return
+
+        # Skip archiving if session too short
+        if session.duration_seconds < self.config.min_session_duration_seconds:
+            logger.info(
+                f"Session too short to archive (max duration): {state_key} "
+                f"({session.duration_seconds}s < {self.config.min_session_duration_seconds}s)"
+            )
+            await self.session_store.restart_session(session.client_id, session.device_id)
+            return
+
+        logger.info(
+            f"Breaking session for max duration: {state_key} session={session.session_id} "
+            f"duration={session.duration_seconds}s segments={session.segment_count}"
+        )
+
+        # Convert to DeviceSession for archive service
+        device_session = DeviceSession(
+            client_id=session.client_id,
+            device_id=session.device_id,
+            session_id=session.session_id,
+            started_at=session.started_at_dt,
+            last_frame_at=session.last_frame_at_dt,
+            first_segment_number=session.first_segment_number,
+            last_segment_number=session.last_segment_number,
+            frame_count=session.frame_count,
+        )
+
+        # Archive first, then restart
+        try:
+            logger.info(
+                f"Creating archive for max-duration session: {state_key} "
+                f"session={session.session_id}"
+            )
+            await self.archive_service.create_archive(device_session)
+        except Exception as e:
+            logger.error(
+                f"Error creating archive for {state_key} (max duration): {e}", exc_info=True
+            )
+
+        # Restart session even if archive fails - device is still active
+        await self.session_store.restart_session(session.client_id, session.device_id)
+
     async def run_continuous(self) -> None:
         """
         Run the offline checker continuously.
@@ -165,6 +237,10 @@ class OfflineChecker:
         logger.info("Offline Checker Service Started (Continuous Mode)")
         logger.info(f"Offline threshold: {self.config.offline_threshold_seconds}s")
         logger.info(f"Min session duration: {self.config.min_session_duration_seconds}s")
+        logger.info(
+            f"Max session duration: {self.config.max_session_duration_seconds}s "
+            f"({'disabled' if self.config.max_session_duration_seconds == 0 else 'enabled'})"
+        )
         logger.info(f"Retention: {self.config.retention_days} days")
         logger.info(f"Check interval: {self.check_interval}s")
         logger.info(
@@ -226,6 +302,10 @@ class OfflineChecker:
         logger.info("Offline Checker Service (One-Shot Mode)")
         logger.info(f"Offline threshold: {self.config.offline_threshold_seconds}s")
         logger.info(f"Min session duration: {self.config.min_session_duration_seconds}s")
+        logger.info(
+            f"Max session duration: {self.config.max_session_duration_seconds}s "
+            f"({'disabled' if self.config.max_session_duration_seconds == 0 else 'enabled'})"
+        )
         logger.info(f"Retention: {self.config.retention_days} days")
         logger.info("=" * 80)
 

--- a/src/stream_processor/service/offline_checker.py
+++ b/src/stream_processor/service/offline_checker.py
@@ -202,7 +202,9 @@ class OfflineChecker:
         # Skip archiving if no segments generated
         if session.first_segment_number < 0 or session.last_segment_number < 0:
             logger.info(f"Session has no segments to archive (max duration): {state_key}")
-            await self.session_store.restart_session(session.client_id, session.device_id)
+            await self.session_store.restart_session(
+                session.client_id, session.device_id, expected_session_id=session.session_id
+            )
             return
 
         # Skip archiving if session too short
@@ -211,7 +213,9 @@ class OfflineChecker:
                 f"Session too short to archive (max duration): {state_key} "
                 f"({session.duration_seconds}s < {self.config.min_session_duration_seconds}s)"
             )
-            await self.session_store.restart_session(session.client_id, session.device_id)
+            await self.session_store.restart_session(
+                session.client_id, session.device_id, expected_session_id=session.session_id
+            )
             return
 
         logger.info(
@@ -244,7 +248,10 @@ class OfflineChecker:
             )
 
         # Restart session even if archive fails - device is still active
-        await self.session_store.restart_session(session.client_id, session.device_id)
+        # Pass expected_session_id to prevent overwriting if another process already restarted
+        await self.session_store.restart_session(
+            session.client_id, session.device_id, expected_session_id=session.session_id
+        )
 
     async def run_continuous(self) -> None:
         """

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -13,11 +13,15 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 
 import redis.asyncio as redis
+from redis.exceptions import WatchError
 
 from ..config.settings import settings
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Maximum retries for optimistic locking
+MAX_CAS_RETRIES = 3
 
 # Redis key prefixes
 SESSION_KEY_PREFIX = "stream:session:"
@@ -122,10 +126,13 @@ class RedisSessionStore:
         expected_session_id: str | None = None,
     ) -> SessionData | None:
         """
-        Update session activity timestamp.
+        Update session activity timestamp using optimistic locking.
 
         Creates a new session if one doesn't exist.
         Called by consumers on every frame receipt.
+
+        Uses Redis WATCH/MULTI/EXEC for compare-and-swap to prevent
+        race conditions with concurrent updates.
 
         Args:
             client_id: Client identifier
@@ -137,46 +144,75 @@ class RedisSessionStore:
             The updated SessionData, or None if session_id mismatch (stale update)
         """
         client = await self.connect()
-
         key = self._session_key(client_id, device_id)
-        now = datetime.now(UTC).isoformat()
+        state_key = f"{client_id}:{device_id}"
 
-        # Try to get existing session
-        existing = await client.get(key)
+        for attempt in range(MAX_CAS_RETRIES):
+            try:
+                # WATCH the key for changes
+                await client.watch(key)
 
-        if existing:
-            session = SessionData.from_json(existing)
+                now = datetime.now(UTC).isoformat()
+                existing = await client.get(key)
 
-            # Validate session_id if provided (reject stale updates)
-            if expected_session_id is not None and session.session_id != expected_session_id:
+                if existing:
+                    session = SessionData.from_json(existing)
+
+                    # Validate session_id if provided (reject stale updates)
+                    if (
+                        expected_session_id is not None
+                        and session.session_id != expected_session_id
+                    ):
+                        await client.unwatch()
+                        logger.debug(
+                            f"Ignoring stale activity update: {session.state_key} "
+                            f"expected={expected_session_id}, current={session.session_id}"
+                        )
+                        return None
+
+                    session.last_frame_at = now
+                    session.frame_count += 1
+                    is_new_session = False
+                else:
+                    # Create new session
+                    session = SessionData(
+                        client_id=client_id,
+                        device_id=device_id,
+                        session_id=str(uuid.uuid4()),
+                        started_at=now,
+                        last_frame_at=now,
+                        first_segment_number=-1,
+                        last_segment_number=-1,
+                        frame_count=1,
+                    )
+                    is_new_session = True
+
+                # Execute atomically
+                async with client.pipeline(transaction=True) as pipe:
+                    if is_new_session:
+                        pipe.sadd(SESSION_INDEX_KEY, state_key)
+                        logger.info(
+                            f"New session started: {session.state_key} "
+                            f"session={session.session_id}"
+                        )
+                    pipe.set(key, session.to_json(), ex=86400)
+                    await pipe.execute()
+
+                return session
+
+            except WatchError:
+                # Key was modified by another client, retry
                 logger.debug(
-                    f"Ignoring stale activity update: {session.state_key} "
-                    f"expected={expected_session_id}, current={session.session_id}"
+                    f"Optimistic lock failed for activity update: {state_key} "
+                    f"(attempt {attempt + 1}/{MAX_CAS_RETRIES})"
                 )
-                return None
+                continue
 
-            session.last_frame_at = now
-            session.frame_count += 1
-        else:
-            # Create new session
-            session = SessionData(
-                client_id=client_id,
-                device_id=device_id,
-                session_id=str(uuid.uuid4()),
-                started_at=now,
-                last_frame_at=now,
-                first_segment_number=-1,
-                last_segment_number=-1,
-                frame_count=1,
-            )
-            logger.info(f"New session started: {session.state_key} session={session.session_id}")
-            # Add to active sessions index
-            await client.sadd(SESSION_INDEX_KEY, session.state_key)  # type: ignore[misc]
-
-        # Save session (with 24h expiry as safety net)
-        await client.set(key, session.to_json(), ex=86400)
-
-        return session
+        # All retries exhausted
+        logger.warning(
+            f"Failed to update activity after {MAX_CAS_RETRIES} retries: {state_key}"
+        )
+        return None
 
     async def update_segment(
         self,
@@ -186,9 +222,12 @@ class RedisSessionStore:
         expected_session_id: str | None = None,
     ) -> SessionData | None:
         """
-        Update session with segment generation info.
+        Update session with segment generation info using optimistic locking.
 
         Called by consumers when a segment is generated.
+
+        Uses Redis WATCH/MULTI/EXEC for compare-and-swap to prevent
+        race conditions with concurrent updates.
 
         Args:
             client_id: Client identifier
@@ -201,39 +240,66 @@ class RedisSessionStore:
             The updated SessionData, or None if session doesn't exist or session_id mismatch
         """
         client = await self.connect()
-
         key = self._session_key(client_id, device_id)
+        state_key = f"{client_id}:{device_id}"
 
-        existing = await client.get(key)
-        if not existing:
-            logger.warning(f"No active session for segment update: {client_id}:{device_id}")
-            return None
+        for attempt in range(MAX_CAS_RETRIES):
+            try:
+                # WATCH the key for changes
+                await client.watch(key)
 
-        session = SessionData.from_json(existing)
+                existing = await client.get(key)
+                if not existing:
+                    await client.unwatch()
+                    logger.warning(f"No active session for segment update: {state_key}")
+                    return None
 
-        # Validate session_id if provided (reject stale updates)
-        if expected_session_id is not None and session.session_id != expected_session_id:
-            logger.debug(
-                f"Ignoring stale segment update: {session.state_key} "
-                f"expected={expected_session_id}, current={session.session_id}"
-            )
-            return None
+                session = SessionData.from_json(existing)
 
-        # Set first segment number if not yet set
-        if session.first_segment_number < 0:
-            session.first_segment_number = segment_number
-            logger.info(
-                f"Session first segment recorded: {session.state_key} segment={segment_number}"
-            )
+                # Validate session_id if provided (reject stale updates)
+                if (
+                    expected_session_id is not None
+                    and session.session_id != expected_session_id
+                ):
+                    await client.unwatch()
+                    logger.debug(
+                        f"Ignoring stale segment update: {session.state_key} "
+                        f"expected={expected_session_id}, current={session.session_id}"
+                    )
+                    return None
 
-        # Update last segment number
-        if segment_number > session.last_segment_number:
-            session.last_segment_number = segment_number
+                # Set first segment number if not yet set
+                if session.first_segment_number < 0:
+                    session.first_segment_number = segment_number
+                    logger.info(
+                        f"Session first segment recorded: {session.state_key} "
+                        f"segment={segment_number}"
+                    )
 
-        # Save session
-        await client.set(key, session.to_json(), ex=86400)
+                # Update last segment number
+                if segment_number > session.last_segment_number:
+                    session.last_segment_number = segment_number
 
-        return session
+                # Execute atomically
+                async with client.pipeline(transaction=True) as pipe:
+                    pipe.set(key, session.to_json(), ex=86400)
+                    await pipe.execute()
+
+                return session
+
+            except WatchError:
+                # Key was modified by another client, retry
+                logger.debug(
+                    f"Optimistic lock failed for segment update: {state_key} "
+                    f"(attempt {attempt + 1}/{MAX_CAS_RETRIES})"
+                )
+                continue
+
+        # All retries exhausted
+        logger.warning(
+            f"Failed to update segment after {MAX_CAS_RETRIES} retries: {state_key}"
+        )
+        return None
 
     async def get_session(self, client_id: str, device_id: str) -> SessionData | None:
         """Get session data for a device."""
@@ -294,9 +360,13 @@ class RedisSessionStore:
         self,
         client_id: str,
         device_id: str,
-    ) -> SessionData:
+        expected_session_id: str | None = None,
+    ) -> SessionData | None:
         """
         Restart a session with a new session_id for max duration breaking.
+
+        Uses optimistic locking to ensure we only restart the session we intend to,
+        preventing race conditions where another process has already restarted it.
 
         The device is still active, so we create a new session that will
         continue tracking from whatever segment the consumer generates next.
@@ -304,31 +374,70 @@ class RedisSessionStore:
         Args:
             client_id: Client identifier
             device_id: Device identifier
+            expected_session_id: If provided, only restart if current session_id matches.
+                                 Returns None if session_id doesn't match (already restarted).
 
         Returns:
-            The new SessionData
+            The new SessionData, or None if session_id mismatch or max retries exceeded
         """
         client = await self.connect()
         key = self._session_key(client_id, device_id)
-        now = datetime.now(UTC).isoformat()
+        state_key = f"{client_id}:{device_id}"
 
-        # Create new session with fresh session_id
-        session = SessionData(
-            client_id=client_id,
-            device_id=device_id,
-            session_id=str(uuid.uuid4()),
-            started_at=now,
-            last_frame_at=now,
-            first_segment_number=-1,  # Will be set on first segment of new session
-            last_segment_number=-1,
-            frame_count=0,
+        for attempt in range(MAX_CAS_RETRIES):
+            try:
+                # WATCH the key for changes
+                await client.watch(key)
+
+                # Verify current session if expected_session_id provided
+                if expected_session_id is not None:
+                    existing = await client.get(key)
+                    if existing:
+                        current_session = SessionData.from_json(existing)
+                        if current_session.session_id != expected_session_id:
+                            await client.unwatch()
+                            logger.info(
+                                f"Session already restarted by another process: {state_key} "
+                                f"expected={expected_session_id}, "
+                                f"current={current_session.session_id}"
+                            )
+                            return None
+
+                now = datetime.now(UTC).isoformat()
+
+                # Create new session with fresh session_id
+                session = SessionData(
+                    client_id=client_id,
+                    device_id=device_id,
+                    session_id=str(uuid.uuid4()),
+                    started_at=now,
+                    last_frame_at=now,
+                    first_segment_number=-1,  # Will be set on first segment of new session
+                    last_segment_number=-1,
+                    frame_count=0,
+                )
+
+                # Execute atomically
+                async with client.pipeline(transaction=True) as pipe:
+                    pipe.set(key, session.to_json(), ex=86400)
+                    await pipe.execute()
+
+                logger.info(
+                    f"Session restarted (max duration): {session.state_key} "
+                    f"new_session={session.session_id}"
+                )
+                return session
+
+            except WatchError:
+                # Key was modified by another client, retry
+                logger.debug(
+                    f"Optimistic lock failed for session restart: {state_key} "
+                    f"(attempt {attempt + 1}/{MAX_CAS_RETRIES})"
+                )
+                continue
+
+        # All retries exhausted
+        logger.warning(
+            f"Failed to restart session after {MAX_CAS_RETRIES} retries: {state_key}"
         )
-
-        logger.info(
-            f"Session restarted (max duration): {session.state_key} "
-            f"new_session={session.session_id}"
-        )
-
-        # Save new session (index entry already exists)
-        await client.set(key, session.to_json(), ex=86400)
-        return session
+        return None

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -192,8 +192,7 @@ class RedisSessionStore:
                     if is_new_session:
                         pipe.sadd(SESSION_INDEX_KEY, state_key)
                         logger.info(
-                            f"New session started: {session.state_key} "
-                            f"session={session.session_id}"
+                            f"New session started: {session.state_key} session={session.session_id}"
                         )
                     pipe.set(key, session.to_json(), ex=86400)
                     await pipe.execute()
@@ -209,9 +208,7 @@ class RedisSessionStore:
                 continue
 
         # All retries exhausted
-        logger.warning(
-            f"Failed to update activity after {MAX_CAS_RETRIES} retries: {state_key}"
-        )
+        logger.warning(f"Failed to update activity after {MAX_CAS_RETRIES} retries: {state_key}")
         return None
 
     async def update_segment(
@@ -257,10 +254,7 @@ class RedisSessionStore:
                 session = SessionData.from_json(existing)
 
                 # Validate session_id if provided (reject stale updates)
-                if (
-                    expected_session_id is not None
-                    and session.session_id != expected_session_id
-                ):
+                if expected_session_id is not None and session.session_id != expected_session_id:
                     await client.unwatch()
                     logger.debug(
                         f"Ignoring stale segment update: {session.state_key} "
@@ -296,9 +290,7 @@ class RedisSessionStore:
                 continue
 
         # All retries exhausted
-        logger.warning(
-            f"Failed to update segment after {MAX_CAS_RETRIES} retries: {state_key}"
-        )
+        logger.warning(f"Failed to update segment after {MAX_CAS_RETRIES} retries: {state_key}")
         return None
 
     async def get_session(self, client_id: str, device_id: str) -> SessionData | None:
@@ -437,7 +429,5 @@ class RedisSessionStore:
                 continue
 
         # All retries exhausted
-        logger.warning(
-            f"Failed to restart session after {MAX_CAS_RETRIES} retries: {state_key}"
-        )
+        logger.warning(f"Failed to restart session after {MAX_CAS_RETRIES} retries: {state_key}")
         return None

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -119,7 +119,8 @@ class RedisSessionStore:
         self,
         client_id: str,
         device_id: str,
-    ) -> SessionData:
+        expected_session_id: str | None = None,
+    ) -> SessionData | None:
         """
         Update session activity timestamp.
 
@@ -129,9 +130,11 @@ class RedisSessionStore:
         Args:
             client_id: Client identifier
             device_id: Device identifier
+            expected_session_id: If provided, only update if session_id matches.
+                                 Returns None if session_id doesn't match (stale update).
 
         Returns:
-            The updated SessionData
+            The updated SessionData, or None if session_id mismatch (stale update)
         """
         client = await self.connect()
 
@@ -143,6 +146,15 @@ class RedisSessionStore:
 
         if existing:
             session = SessionData.from_json(existing)
+
+            # Validate session_id if provided (reject stale updates)
+            if expected_session_id is not None and session.session_id != expected_session_id:
+                logger.debug(
+                    f"Ignoring stale activity update: {session.state_key} "
+                    f"expected={expected_session_id}, current={session.session_id}"
+                )
+                return None
+
             session.last_frame_at = now
             session.frame_count += 1
         else:
@@ -171,6 +183,7 @@ class RedisSessionStore:
         client_id: str,
         device_id: str,
         segment_number: int,
+        expected_session_id: str | None = None,
     ) -> SessionData | None:
         """
         Update session with segment generation info.
@@ -181,9 +194,11 @@ class RedisSessionStore:
             client_id: Client identifier
             device_id: Device identifier
             segment_number: Current segment number
+            expected_session_id: If provided, only update if session_id matches.
+                                 Returns None if session_id doesn't match (stale update).
 
         Returns:
-            The updated SessionData, or None if session doesn't exist
+            The updated SessionData, or None if session doesn't exist or session_id mismatch
         """
         client = await self.connect()
 
@@ -195,6 +210,14 @@ class RedisSessionStore:
             return None
 
         session = SessionData.from_json(existing)
+
+        # Validate session_id if provided (reject stale updates)
+        if expected_session_id is not None and session.session_id != expected_session_id:
+            logger.debug(
+                f"Ignoring stale segment update: {session.state_key} "
+                f"expected={expected_session_id}, current={session.session_id}"
+            )
+            return None
 
         # Set first segment number if not yet set
         if session.first_segment_number < 0:

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -266,3 +266,46 @@ class RedisSessionStore:
         deleted: int = await client.delete(key)
 
         return deleted > 0
+
+    async def restart_session(
+        self,
+        client_id: str,
+        device_id: str,
+    ) -> SessionData:
+        """
+        Restart a session with a new session_id for max duration breaking.
+
+        The device is still active, so we create a new session that will
+        continue tracking from whatever segment the consumer generates next.
+
+        Args:
+            client_id: Client identifier
+            device_id: Device identifier
+
+        Returns:
+            The new SessionData
+        """
+        client = await self.connect()
+        key = self._session_key(client_id, device_id)
+        now = datetime.now(UTC).isoformat()
+
+        # Create new session with fresh session_id
+        session = SessionData(
+            client_id=client_id,
+            device_id=device_id,
+            session_id=str(uuid.uuid4()),
+            started_at=now,
+            last_frame_at=now,
+            first_segment_number=-1,  # Will be set on first segment of new session
+            last_segment_number=-1,
+            frame_count=0,
+        )
+
+        logger.info(
+            f"Session restarted (max duration): {session.state_key} "
+            f"new_session={session.session_id}"
+        )
+
+        # Save new session (index entry already exists)
+        await client.set(key, session.to_json(), ex=86400)
+        return session


### PR DESCRIPTION
## Summary

- Add configurable `max_session_duration_seconds` (default 2 hours) to automatically break long-running sessions
- When max duration is exceeded, archive the current session and seamlessly restart with a new session_id
- Consumer continues unaware, generating segments at its current number

## Problem

Some devices never stop transmitting, so they never trigger offline detection and never convert to deferred transmissions.

## Solution

The `OfflineChecker` now checks for two conditions:
1. **Offline** (priority): idle time > 60s → end session completely
2. **Max duration**: duration >= 2 hours → archive and restart seamlessly

## Test plan

- [ ] Set `ARCHIVE_MAX_SESSION_DURATION_SECONDS=120` (2 min) in dev
- [ ] Start a continuous stream
- [ ] Verify session breaks after 2 minutes and archive is created
- [ ] Verify new session starts seamlessly with new session_id
- [ ] Verify segments continue uninterrupted in live playlist

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable maximum session duration with automatic archiving and restart when exceeded
  * Ability to restart sessions to reset tracking while continuing device monitoring

* **Bug Fixes / Reliability**
  * Safer, atomic session updates to reduce race conditions and ignore stale updates
  * Improved handling and logging around session termination, archiving, and restart

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->