### PR TITLE
feat: parallelize frame pipeline to clear segment backlog and restore real-time HLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,24 @@ This service consumes frame events from Apache Pulsar and generates HLS (HTTP Li
 │                          │                                       │
 │                          ▼                                       │
 │  ┌────────────────────────────────────────────────────────────┐ │
-│  │  Frame Accumulator (per device)                            │ │
-│  │  - Collects frames until segment threshold                 │ │
-│  │  - Triggers segment generation every 30s or N frames       │ │
+│  │  Receive loop (decoupled from generation)                  │ │
+│  │  - Parses each frame, routes it to its device queue, acks  │ │
+│  │  - Blocking receive() runs on a dedicated IO thread        │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                          │                                       │
+│                          ▼                                       │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  Per-device workers (one asyncio task per device)          │ │
+│  │  - Drain a bounded per-device queue (backpressure)         │ │
+│  │  - Accumulate frames; trigger on N frames or time          │ │
+│  │  - Submit FFmpeg jobs to the worker pool                   │ │
 │  └────────────────────────────────────────────────────────────┘ │
 │                          │                                       │
 │                          ▼                                       │
 │  ┌────────────────────────────────────────────────────────────┐ │
 │  │  FFmpeg Worker Pool (ThreadPoolExecutor)                   │ │
 │  │  - MAX_WORKERS concurrent FFmpeg processes                 │ │
+│  │  - Different devices encode in parallel; per device serial │ │
 │  │  - Generates HLS segments (.ts) + playlist (.m3u8)         │ │
 │  └────────────────────────────────────────────────────────────┘ │
 │                          │                                       │
@@ -237,6 +246,35 @@ The service scales horizontally via Pulsar's **Key_Shared** subscription:
 
 Deploy multiple instances (K8s replicas) and Pulsar will distribute devices across them while maintaining ordering per device.
 
+### Concurrency model
+
+Within a single pod, consumption is decoupled from segment generation. The receive
+loop only parses each frame and hands it to a **per-device worker** (one `asyncio`
+task per device) via a bounded queue, then acks. Each worker generates its own
+device's segments **serially** (preserving order and the per-session PTS timeline),
+but workers for **different devices run concurrently**, bounded by
+`PROCESSING_MAX_WORKERS` FFmpeg threads. FFmpeg is CPU-bound, so set `MAX_WORKERS`
+near the pod's vCPU count and scale **pods** for more total throughput.
+
+The bounded per-device queue (`PROCESSING_DEVICE_QUEUE_MAXSIZE`) provides
+end-to-end backpressure: when a device's queue fills, the receive loop stops
+pulling from Pulsar (which stops the broker delivering) instead of buffering
+frames unbounded in memory.
+
+### Segment numbering across pods
+
+Key_Shared pins each device to a single pod, so per-device segment numbering is
+safe by design. On device handoff (pod scale up/down or restart) the new pod
+resumes numbering from the highest `.ts` in storage. To also close the brief
+rebalance window where two pods may momentarily touch the same device, enable
+`REDIS_SEGMENT_COUNTER_ENABLED=true`: segment numbers are then allocated via an
+atomic Redis `INCR` per device, so they can never collide or overwrite — strongly
+recommended when running more than one pod.
+
+> **Prerequisite:** the publisher must set the Pulsar message **key** to the
+> device (so Key_Shared keeps each device on one consumer). Without a key,
+> multiple pods will process the same device and break ordering and numbering.
+
 ## HLS Output
 
 Generated HLS streams are compatible with all major browsers:
@@ -381,6 +419,7 @@ Prometheus metrics available at `http://localhost:9090/metrics`:
 - `stream_processor_frames_received_total` - Total frames received
 - `stream_processor_segments_generated_total` - Total HLS segments generated
 - `stream_processor_active_devices` - Currently active devices
+- `stream_processor_queued_frames` - Frames buffered across per-device queues awaiting generation (backlog signal)
 - `stream_processor_ffmpeg_duration_seconds` - FFmpeg processing time histogram
 
 ## License

--- a/env.example
+++ b/env.example
@@ -20,6 +20,10 @@ STORAGE_BASE_PATH=/mnt/streamhub/streams
 # STORAGE_GCS_PROJECT_ID=your-project-id
 
 # Processing Configuration
+# Max concurrent FFmpeg segment generations (one device generates at a time;
+# this bounds how many DIFFERENT devices encode in parallel). Right-size near
+# the pod's vCPU count — FFmpeg is CPU-bound — and scale pods for more total
+# throughput.
 PROCESSING_MAX_WORKERS=50
 PROCESSING_SEGMENT_DURATION_SECONDS=30
 PROCESSING_FRAMES_PER_SEGMENT=6
@@ -27,11 +31,20 @@ PROCESSING_RETENTION_HOURS=24
 PROCESSING_FRAME_INTERVAL_SECONDS=5
 PROCESSING_OUTPUT_FRAMERATE=1
 PROCESSING_VIDEO_WIDTH=1920
+# Max frames buffered per device before the receive loop blocks (backpressure).
+PROCESSING_DEVICE_QUEUE_MAXSIZE=256
+# How often an idle device worker wakes to flush a time-based segment.
+PROCESSING_SEGMENT_TIMER_INTERVAL_SECONDS=10
 
 # Redis Configuration (REQUIRED for offline detection with separate checker service)
 # Consumer writes session state to Redis, offline-checker reads it
 REDIS_URL=redis://localhost:6379
 REDIS_ENABLED=true
+# Allocate segment numbers via an atomic Redis INCR per device. Recommended
+# when running MORE THAN ONE consumer pod: it keeps per-device numbering
+# collision-free even during the brief Key_Shared rebalance window. Requires
+# REDIS_ENABLED=true. Defaults to false (in-memory numbering, single-pod safe).
+REDIS_SEGMENT_COUNTER_ENABLED=false
 
 # Metrics Configuration
 METRICS_PORT=9090

--- a/src/stream_processor/config/settings.py
+++ b/src/stream_processor/config/settings.py
@@ -57,6 +57,21 @@ class ProcessingConfig(BaseSettings):
     segment_duration_seconds: int = Field(default=6, description="HLS segment duration (playback)")
     frames_per_segment: int = Field(default=6, description="Frames per segment")
     retention_hours: int = Field(default=24, description="Hours of video to retain")
+    device_queue_maxsize: int = Field(
+        default=256,
+        description=(
+            "Max frames buffered per device before the receive loop blocks. "
+            "Provides end-to-end backpressure: when a device's queue is full the "
+            "consumer stops pulling from Pulsar instead of growing memory unbounded."
+        ),
+    )
+    segment_timer_interval_seconds: int = Field(
+        default=10,
+        description=(
+            "How often an idle device worker wakes to flush a time-based segment "
+            "when frames arrive sporadically (no new frame for max_segment_wait_seconds)."
+        ),
+    )
     frame_interval_seconds: int = Field(
         default=1, description="Display duration per frame in output video"
     )
@@ -80,6 +95,16 @@ class RedisConfig(BaseSettings):
     playlist_enabled: bool = Field(
         default=False,
         description="Enable Redis-based playlist metadata (requires enabled=True)",
+    )
+    segment_counter_enabled: bool = Field(
+        default=False,
+        description=(
+            "Use an atomic Redis INCR per device to allocate segment numbers "
+            "(requires enabled=True). Makes segment numbering safe across multiple "
+            "pods, including the brief Key_Shared rebalance window where two pods "
+            "may momentarily touch the same device. When disabled, numbering is "
+            "in-memory and seeded from storage on startup."
+        ),
     )
 
 

--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -176,10 +176,6 @@ class StreamProcessorConsumer:
         other device workers keep running on the event loop, so generation is
         concurrent across devices (bounded by the FFmpeg thread pool).
         """
-        frames_per_segment = self.processing_config.frames_per_segment
-        max_wait = self.processing_config.max_segment_wait_seconds
-        interval = self.processing_config.segment_timer_interval_seconds
-
         try:
             state = await self._init_device_state(client_id, device_id)
         except Exception as e:
@@ -189,40 +185,53 @@ class StreamProcessorConsumer:
             self.device_workers.pop(state_key, None)
             return
 
-        shutting_down = False
-        try:
-            while not shutting_down:
-                # Wait for a frame, but wake periodically to flush time-based
-                # segments when frames arrive sporadically.
-                try:
-                    item = await asyncio.wait_for(queue.get(), timeout=interval)
-                except TimeoutError:
-                    item = None
-                else:
-                    if item is self._SHUTDOWN:
-                        shutting_down = True
-                    elif isinstance(item, FrameEvent):
-                        try:
-                            await self._accumulate_frame(state, item)
-                        except Exception as e:
-                            processing_errors_total.labels(
-                                device_id=state_key, error_type="accumulate"
-                            ).inc()
-                            logger.error(
-                                f"Error accumulating frame for {state_key}: {e}", exc_info=True
-                            )
+        frames_per_segment = self.processing_config.frames_per_segment
+        max_wait = self.processing_config.max_segment_wait_seconds
+        interval = self.processing_config.segment_timer_interval_seconds
 
+        try:
+            shutting_down = False
+            while not shutting_down:
+                shutting_down = await self._consume_one(state, queue, interval)
                 if state.should_generate_segment(frames_per_segment, max_wait_seconds=max_wait):
                     await self._generate_segment(state)
-        except asyncio.CancelledError:
-            raise
         finally:
             # Flush remaining frames so a graceful stop doesn't drop a partial segment.
-            if state.pending_frames:
-                try:
-                    await self._generate_segment(state)
-                except Exception as e:
-                    logger.error(f"Error flushing frames for {state_key} on shutdown: {e}")
+            await self._flush_pending_frames(state)
+
+    async def _consume_one(self, state: DeviceState, queue: asyncio.Queue, interval: int) -> bool:
+        """
+        Pull one queued item (or time out) and fold it into the device state.
+
+        Waking on the timeout lets time-based segments flush when frames arrive
+        sporadically. Returns True when the shutdown sentinel is received.
+        """
+        try:
+            item = await asyncio.wait_for(queue.get(), timeout=interval)
+        except TimeoutError:
+            return False
+
+        if item is self._SHUTDOWN:
+            return True
+
+        if isinstance(item, FrameEvent):
+            try:
+                await self._accumulate_frame(state, item)
+            except Exception as e:
+                processing_errors_total.labels(
+                    device_id=state.state_key, error_type="accumulate"
+                ).inc()
+                logger.error(f"Error accumulating frame for {state.state_key}: {e}", exc_info=True)
+        return False
+
+    async def _flush_pending_frames(self, state: DeviceState) -> None:
+        """Generate a final segment from any leftover frames (used on shutdown)."""
+        if not state.pending_frames:
+            return
+        try:
+            await self._generate_segment(state)
+        except Exception as e:
+            logger.error(f"Error flushing frames for {state.state_key} on shutdown: {e}")
 
     async def _accumulate_frame(self, state: DeviceState, event: FrameEvent) -> None:
         """Apply optional watermark, append the frame, and update session activity."""
@@ -496,13 +505,17 @@ class StreamProcessorConsumer:
 
         logger.info(f"Draining {len(self.device_workers)} device worker(s)...")
 
+        # Snapshot before awaiting: a worker may still be created/removed on the
+        # event loop while we await the puts below.
+        queues = list(self.device_queues.values())
+        workers = list(self.device_workers.items())
+
         # Workers keep draining the event loop, so these puts succeed even on
         # bounded queues. The sentinel is the last item enqueued (the receive
         # loop has already stopped), so all real frames are processed first.
-        for queue in list(self.device_queues.values()):
+        for queue in queues:
             await queue.put(self._SHUTDOWN)
 
-        workers = list(self.device_workers.items())
         results = await asyncio.gather(*(task for _, task in workers), return_exceptions=True)
         for (state_key, _), result in zip(workers, results, strict=False):
             if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):

--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -1,6 +1,12 @@
 """
 Pulsar consumer for frame events with Key_Shared subscription.
-Processes frames and triggers HLS segment generation.
+
+Consumption is decoupled from segment generation: the receive loop only
+parses, routes each frame to a per-device queue, and acks. One asyncio worker
+per device drains its queue and submits FFmpeg jobs to a thread pool. Because
+each device has its own worker, segments for different devices are generated
+concurrently (bounded by the worker pool), while ordering within a device is
+preserved.
 """
 
 import asyncio
@@ -22,6 +28,7 @@ from ..utils.metrics import (
     active_devices_gauge,
     frames_received_total,
     processing_errors_total,
+    queued_frames_gauge,
 )
 
 logger = get_logger(__name__)
@@ -31,9 +38,13 @@ class StreamProcessorConsumer:
     """
     Pulsar consumer for stream processing.
 
-    Uses Key_Shared subscription to ensure ordering per device
-    while allowing horizontal scaling across multiple instances.
+    Uses Key_Shared subscription to ensure ordering per device while allowing
+    horizontal scaling across multiple instances. Within a single instance,
+    a per-device worker model provides concurrency across devices.
     """
+
+    # Sentinel pushed onto a device queue to tell its worker to drain and exit.
+    _SHUTDOWN = object()
 
     def __init__(self, use_redis: bool = True):
         """
@@ -48,8 +59,13 @@ class StreamProcessorConsumer:
         self.archive_config = settings.archive
         self.watermark_config = settings.watermark
 
-        # Device state tracking (in-memory)
+        # Device state tracking (in-memory). Each device's state is owned
+        # exclusively by its worker coroutine, so no per-device lock is needed.
         self.device_states: dict[str, DeviceState] = {}
+
+        # Per-device frame queues and the worker task draining each one.
+        self.device_queues: dict[str, asyncio.Queue] = {}
+        self.device_workers: dict[str, asyncio.Task] = {}
 
         # HLS generator service
         self.hls_generator = HLSGenerator()
@@ -60,18 +76,20 @@ class StreamProcessorConsumer:
             self.watermark_service = WatermarkService(self.watermark_config)
             logger.info("Watermark service enabled")
 
-        # Thread pool for FFmpeg workers
+        # Thread pool for FFmpeg workers (bounds concurrent segment generation).
         self.executor = ThreadPoolExecutor(
             max_workers=self.processing_config.max_workers, thread_name_prefix="ffmpeg-worker-"
         )
+
+        # Dedicated single thread for the blocking Pulsar receive() call so it
+        # never stalls the asyncio event loop.
+        self.io_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="pulsar-recv-")
 
         # Pulsar client and consumer (initialized on run)
         self.client: pulsar.Client | None = None
         self.consumer: pulsar.Consumer | None = None
         self.running = False
-
-        # Segment generation lock per device
-        self.device_locks: dict[str, asyncio.Lock] = {}
+        self._stopping = False
 
         # Redis session store for distributed offline detection
         # The offline-checker service reads this to detect offline devices
@@ -81,58 +99,139 @@ class StreamProcessorConsumer:
             self.session_store = RedisSessionStore()
             logger.info("Redis session tracking enabled for offline detection")
 
-        # Redis playlist store for dynamic playlist generation
-        # Stores segment metadata for on-the-fly playlist generation by quarkus
+        # Redis playlist store: hosts both the on-the-fly playlist metadata and
+        # the atomic per-device segment counter. Either feature needs the store.
+        self.playlist_enabled = (
+            use_redis and settings.redis.enabled and settings.redis.playlist_enabled
+        )
+        self.segment_counter_enabled = (
+            use_redis and settings.redis.enabled and settings.redis.segment_counter_enabled
+        )
         self.playlist_store: RedisPlaylistStore | None = None
-
-        if use_redis and settings.redis.enabled and settings.redis.playlist_enabled:
+        if self.playlist_enabled or self.segment_counter_enabled:
             self.playlist_store = RedisPlaylistStore()
-            logger.info("Redis playlist store enabled for dynamic playlist generation")
-
-    def _get_or_create_state(self, client_id: str, device_id: str) -> DeviceState:
-        """Get or create device state using client_id:device_id key."""
-        state_key = f"{client_id}:{device_id}"
-        if state_key not in self.device_states:
-            # Check for existing segments to resume numbering
-            highest_segment = self.hls_generator.get_highest_segment_number(client_id, device_id)
-            initial_segment = highest_segment + 1 if highest_segment >= 0 else 0
-
-            self.device_states[state_key] = DeviceState(
-                client_id=client_id,
-                device_id=device_id,
-                current_segment_number=initial_segment,
-            )
-            active_devices_gauge.inc()
             logger.info(
-                f"New device registered: {state_key} (starting at segment {initial_segment})"
+                "Redis playlist store enabled "
+                f"(playlist={self.playlist_enabled}, segment_counter={self.segment_counter_enabled})"
             )
-        return self.device_states[state_key]
 
-    def _get_device_lock(self, state_key: str) -> asyncio.Lock:
-        """Get or create async lock for device using state_key."""
-        if state_key not in self.device_locks:
-            self.device_locks[state_key] = asyncio.Lock()
-        return self.device_locks[state_key]
-
-    async def _process_frame(self, event: FrameEvent) -> None:
+    async def _init_device_state(self, client_id: str, device_id: str) -> DeviceState:
         """
-        Process a single frame event.
+        Create and register state for a device on first sight.
 
-        Accumulates frames and triggers segment generation when threshold is reached.
+        The storage scan that resumes segment numbering is offloaded to the
+        thread pool so it never blocks the event loop, and (when enabled) the
+        Redis segment counter is seeded so multi-pod numbering stays atomic.
         """
-        client_id = event.client_id
-        device_id = sanitize_path_component(event.device_id)
         state_key = f"{client_id}:{device_id}"
-        lock = self._get_device_lock(state_key)
 
+        loop = asyncio.get_event_loop()
+        highest = await loop.run_in_executor(
+            self.executor,
+            self.hls_generator.get_highest_segment_number,
+            client_id,
+            device_id,
+        )
+        initial_segment = highest + 1 if highest >= 0 else 0
+
+        state = DeviceState(
+            client_id=client_id,
+            device_id=device_id,
+            current_segment_number=initial_segment,
+        )
+        self.device_states[state_key] = state
+        active_devices_gauge.inc()
+
+        if self.segment_counter_enabled and self.playlist_store:
+            try:
+                await self.playlist_store.seed_segment_counter(
+                    client_id, device_id, initial_segment
+                )
+            except Exception as e:
+                logger.warning(f"Failed to seed Redis segment counter for {state_key}: {e}")
+
+        logger.info(f"New device registered: {state_key} (starting at segment {initial_segment})")
+        return state
+
+    def _get_or_create_worker(
+        self, state_key: str, client_id: str, device_id: str
+    ) -> asyncio.Queue:
+        """Get the device's frame queue, spawning its worker task on first sight."""
+        queue = self.device_queues.get(state_key)
+        if queue is None:
+            queue = asyncio.Queue(maxsize=self.processing_config.device_queue_maxsize)
+            self.device_queues[state_key] = queue
+            self.device_workers[state_key] = asyncio.create_task(
+                self._device_worker(state_key, client_id, device_id, queue)
+            )
+        return queue
+
+    async def _device_worker(
+        self, state_key: str, client_id: str, device_id: str, queue: asyncio.Queue
+    ) -> None:
+        """
+        Drain one device's frame queue and generate its segments serially.
+
+        Blocking on `_generate_segment` here only serializes *this* device;
+        other device workers keep running on the event loop, so generation is
+        concurrent across devices (bounded by the FFmpeg thread pool).
+        """
+        frames_per_segment = self.processing_config.frames_per_segment
+        max_wait = self.processing_config.max_segment_wait_seconds
+        interval = self.processing_config.segment_timer_interval_seconds
+
+        try:
+            state = await self._init_device_state(client_id, device_id)
+        except Exception as e:
+            logger.error(f"Failed to initialize device state for {state_key}: {e}", exc_info=True)
+            # Unregister so a later frame can retry creating the worker.
+            self.device_queues.pop(state_key, None)
+            self.device_workers.pop(state_key, None)
+            return
+
+        shutting_down = False
+        try:
+            while not shutting_down:
+                # Wait for a frame, but wake periodically to flush time-based
+                # segments when frames arrive sporadically.
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=interval)
+                except TimeoutError:
+                    item = None
+                else:
+                    if item is self._SHUTDOWN:
+                        shutting_down = True
+                    elif isinstance(item, FrameEvent):
+                        try:
+                            await self._accumulate_frame(state, item)
+                        except Exception as e:
+                            processing_errors_total.labels(
+                                device_id=state_key, error_type="accumulate"
+                            ).inc()
+                            logger.error(
+                                f"Error accumulating frame for {state_key}: {e}", exc_info=True
+                            )
+
+                if state.should_generate_segment(frames_per_segment, max_wait_seconds=max_wait):
+                    await self._generate_segment(state)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            # Flush remaining frames so a graceful stop doesn't drop a partial segment.
+            if state.pending_frames:
+                try:
+                    await self._generate_segment(state)
+                except Exception as e:
+                    logger.error(f"Error flushing frames for {state_key} on shutdown: {e}")
+
+    async def _accumulate_frame(self, state: DeviceState, event: FrameEvent) -> None:
+        """Apply optional watermark, append the frame, and update session activity."""
         # Apply watermark if enabled
         frame_path = event.frame_path
         if self.watermark_service and event.request_timestamp:
             try:
-                # Use request_timestamp if available, otherwise fall back to timestamp
-                timestamp = event.request_timestamp
                 frame_path = await self.watermark_service.add_timestamp_watermark(
-                    event.frame_path, timestamp
+                    event.frame_path, event.request_timestamp
                 )
                 logger.debug(f"Watermark applied to {frame_path}")
             except Exception as e:
@@ -140,44 +239,54 @@ class StreamProcessorConsumer:
                 # Continue with original frame path if watermarking fails
                 frame_path = event.frame_path
 
-        async with lock:
-            state = self._get_or_create_state(client_id, device_id)
+        state.add_frame(frame_path, event.timestamp)
+        frames_received_total.labels(device_id=state.state_key).inc()
 
-            # Add frame to pending
-            state.add_frame(frame_path, event.timestamp)
-            frames_received_total.labels(device_id=state_key).inc()
-
-            # Update session activity in Redis (for offline-checker service).
-            # The returned SessionData lets us detect a session boundary and
-            # reset the per-session cumulative PTS offset so each archive
-            # starts at PTS=0 and stays continuous within the session.
-            if self.session_store:
-                session_data = await self.session_store.update_activity(client_id, device_id)
-                if session_data is not None and session_data.session_id != state.current_session_id:
-                    if state.current_session_id is not None:
-                        logger.info(
-                            f"Session boundary for {state_key}: "
-                            f"{state.current_session_id} -> {session_data.session_id}; "
-                            f"resetting PTS offset"
-                        )
-                    state.reset_for_session(session_data.session_id)
-
-            logger.debug(
-                f"Frame received for {state_key}: {frame_path} (pending: {state.frame_count})"
+        # Update session activity in Redis (for offline-checker service).
+        # The returned SessionData lets us detect a session boundary and reset
+        # the per-session cumulative PTS offset so each archive starts at PTS=0
+        # and stays continuous within the session.
+        if self.session_store:
+            session_data = await self.session_store.update_activity(
+                state.client_id, state.device_id
             )
+            if session_data is not None and session_data.session_id != state.current_session_id:
+                if state.current_session_id is not None:
+                    logger.info(
+                        f"Session boundary for {state.state_key}: "
+                        f"{state.current_session_id} -> {session_data.session_id}; "
+                        f"resetting PTS offset"
+                    )
+                state.reset_for_session(session_data.session_id)
 
-            # Check if we should generate a segment
-            if state.should_generate_segment(
-                self.processing_config.frames_per_segment,
-                max_wait_seconds=self.processing_config.max_segment_wait_seconds,
-            ):
-                await self._generate_segment(state)
+        logger.debug(
+            f"Frame received for {state.state_key}: {frame_path} (pending: {state.frame_count})"
+        )
+
+    async def _next_segment_number(self, state: DeviceState) -> int:
+        """
+        Allocate the next segment number for a device.
+
+        Prefers the atomic Redis counter (safe across pods); falls back to the
+        in-memory counter if Redis is disabled or momentarily unavailable.
+        """
+        if self.segment_counter_enabled and self.playlist_store:
+            try:
+                return await self.playlist_store.next_segment_number(
+                    state.client_id, state.device_id
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Redis segment counter unavailable for {state.state_key}, "
+                    f"falling back to in-memory numbering: {e}"
+                )
+        return state.current_segment_number
 
     async def _add_segment_to_playlist(
         self, client_id: str, device_id: str, segment_number: int
     ) -> None:
         """Add segment to playlist store in Redis for dynamic playlist generation."""
-        if not self.playlist_store:
+        if not (self.playlist_store and self.playlist_enabled):
             return
         try:
             await self.playlist_store.add_segment(client_id, device_id, segment_number)
@@ -193,17 +302,18 @@ class StreamProcessorConsumer:
         device_id = state.device_id
         state_key = state.state_key
         frames = state.pending_frames.copy()
-        segment_number = state.current_segment_number
 
         if not frames:
             logger.warning(f"No frames to process for {state_key}")
             return
 
+        segment_number = await self._next_segment_number(state)
+
         logger.info(f"Generating segment {segment_number} for {state_key} ({len(frames)} frames)")
 
         try:
-            # Run FFmpeg in thread pool. Pass the per-session cumulative
-            # offset so the generated segment's PTS continues the timeline.
+            # Run FFmpeg in thread pool. Pass the per-session cumulative offset
+            # so the generated segment's PTS continues the timeline.
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(
                 self.executor,
@@ -239,56 +349,55 @@ class StreamProcessorConsumer:
             processing_errors_total.labels(device_id=state_key, error_type="ffmpeg").inc()
             logger.error(f"Failed to generate segment for {state_key}: {e}", exc_info=True)
 
-    async def _handle_message(self, msg) -> None:
-        """Handle a single Pulsar message."""
+    def _blocking_receive(self) -> pulsar.Message | None:
+        """Blocking Pulsar receive, run on the dedicated io thread."""
+        assert self.consumer is not None
+        try:
+            return self.consumer.receive(timeout_millis=1000)
+        except pulsar.Timeout:
+            return None
+
+    async def _dispatch(self, msg: pulsar.Message) -> None:
+        """Parse a Pulsar message, route the frame to its device worker, and ack."""
         if self.consumer is None:
             logger.error("Consumer not initialized")
             return
 
         try:
-            # Parse message
             data = json.loads(msg.data().decode("utf-8"))
             event = FrameEvent.model_validate(data)
-
-            # Process the frame
-            await self._process_frame(event)
-
-            # Acknowledge the message
-            self.consumer.acknowledge(msg)
-
         except json.JSONDecodeError as e:
             processing_errors_total.labels(device_id="unknown", error_type="json_parse").inc()
             logger.error(f"Failed to parse message: {e}")
             self.consumer.negative_acknowledge(msg)
-
+            return
         except Exception as e:
             processing_errors_total.labels(device_id="unknown", error_type="processing").inc()
-            logger.error(f"Error processing message: {e}", exc_info=True)
+            logger.error(f"Error parsing message: {e}", exc_info=True)
             self.consumer.negative_acknowledge(msg)
+            return
 
-    async def _segment_timer(self) -> None:
-        """
-        Background task to check for devices that need segment generation.
+        client_id = event.client_id
+        device_id = sanitize_path_component(event.device_id)
+        state_key = f"{client_id}:{device_id}"
+        queue = self._get_or_create_worker(state_key, client_id, device_id)
 
-        Handles the case where frames arrive sporadically and we need to
-        generate segments based on time threshold rather than frame count.
-        """
+        # Backpressure: when this device's queue is full, awaiting put parks
+        # only this receive coroutine — device workers keep draining on the
+        # event loop — so the broker slows delivery instead of us buffering
+        # frames unbounded in memory.
+        await queue.put(event)
+        self.consumer.acknowledge(msg)
+
+    async def _update_metrics_loop(self) -> None:
+        """Periodically publish the total queued-frame backlog for observability."""
         while self.running:
-            await asyncio.sleep(10)  # Check every 10 seconds
-
-            for state_key, state in list(self.device_states.items()):
-                if state.should_generate_segment(
-                    self.processing_config.frames_per_segment,
-                    max_wait_seconds=self.processing_config.max_segment_wait_seconds,
-                ):
-                    lock = self._get_device_lock(state_key)
-                    if not lock.locked():
-                        async with lock:
-                            if state.should_generate_segment(
-                                self.processing_config.frames_per_segment,
-                                max_wait_seconds=self.processing_config.max_segment_wait_seconds,
-                            ):
-                                await self._generate_segment(state)
+            await asyncio.sleep(5)
+            try:
+                total = sum(q.qsize() for q in self.device_queues.values())
+                queued_frames_gauge.set(total)
+            except Exception:
+                pass
 
     async def run(self) -> None:
         """
@@ -301,8 +410,12 @@ class StreamProcessorConsumer:
         logger.info(f"Topic: {self.config.topic}")
         logger.info(f"Subscription: {self.config.subscription}")
         logger.info(f"Max Workers: {self.processing_config.max_workers}")
+        logger.info(f"Device queue maxsize: {self.processing_config.device_queue_maxsize}")
         logger.info(f"Redis session tracking: {'enabled' if self.session_store else 'disabled'}")
-        logger.info(f"Redis playlist store: {'enabled' if self.playlist_store else 'disabled'}")
+        logger.info(f"Redis playlist store: {'enabled' if self.playlist_enabled else 'disabled'}")
+        logger.info(
+            f"Redis segment counter: {'enabled' if self.segment_counter_enabled else 'disabled'}"
+        )
         logger.info(f"Watermark: {'enabled' if self.watermark_service else 'disabled'}")
         logger.info("=" * 80)
 
@@ -338,7 +451,6 @@ class StreamProcessorConsumer:
                 subscription_name=self.config.subscription,
                 consumer_type=pulsar.ConsumerType.KeyShared,
                 consumer_name=self.config.consumer_name,
-                # Process messages one at a time per key (device)
                 receiver_queue_size=1000,
             )
 
@@ -347,29 +459,27 @@ class StreamProcessorConsumer:
 
             self.running = True
 
-            # Start segment timer task
-            timer_task = asyncio.create_task(self._segment_timer())
+            # Start background metrics task
+            metrics_task = asyncio.create_task(self._update_metrics_loop())
 
-            # Main message loop
+            # Main receive loop: receive (off the event loop) -> dispatch -> ack.
+            # Segment generation happens in per-device workers, not here.
+            loop = asyncio.get_event_loop()
             while self.running:
                 try:
-                    # Receive message with timeout
-                    assert self.consumer is not None  # For type checker
-                    msg = self.consumer.receive(timeout_millis=1000)
-                    await self._handle_message(msg)
-
-                except pulsar.Timeout:
-                    # No message received, continue
-                    continue
+                    msg = await loop.run_in_executor(self.io_executor, self._blocking_receive)
+                    if msg is None:
+                        continue
+                    await self._dispatch(msg)
                 except Exception as e:
                     if self.running:
                         logger.error(f"Error receiving message: {e}")
                         await asyncio.sleep(1)
 
             # Cancel background tasks
-            timer_task.cancel()
+            metrics_task.cancel()
             try:
-                await timer_task
+                await metrics_task
             except asyncio.CancelledError:
                 pass
 
@@ -379,16 +489,28 @@ class StreamProcessorConsumer:
         finally:
             await self.stop()
 
-    async def _flush_pending_frames(self) -> None:
-        """Process any remaining frames for all devices."""
-        for state_key, state in self.device_states.items():
-            if not state.pending_frames:
-                continue
-            logger.info(f"Processing remaining frames for {state_key}")
-            try:
-                await self._generate_segment(state)
-            except Exception as e:
-                logger.error(f"Error processing remaining frames: {e}")
+    async def _shutdown_workers(self) -> None:
+        """Signal all device workers to flush and exit, then await them."""
+        if not self.device_workers:
+            return
+
+        logger.info(f"Draining {len(self.device_workers)} device worker(s)...")
+
+        # Workers keep draining the event loop, so these puts succeed even on
+        # bounded queues. The sentinel is the last item enqueued (the receive
+        # loop has already stopped), so all real frames are processed first.
+        for queue in list(self.device_queues.values()):
+            await queue.put(self._SHUTDOWN)
+
+        workers = list(self.device_workers.items())
+        results = await asyncio.gather(*(task for _, task in workers), return_exceptions=True)
+        for (state_key, _), result in zip(workers, results, strict=False):
+            if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
+                logger.error(f"Device worker {state_key} ended with error: {result}")
+
+        self.device_workers.clear()
+        self.device_queues.clear()
+        logger.info("All device workers stopped")
 
     async def _close_async_resource(self, resource, name: str) -> None:
         """Safely close an async resource with error logging."""
@@ -410,14 +532,19 @@ class StreamProcessorConsumer:
 
     async def stop(self) -> None:
         """Stop the consumer gracefully."""
+        if self._stopping:
+            return
+        self._stopping = True
+
         logger.info("Stopping consumer...")
         self.running = False
 
-        await self._flush_pending_frames()
+        await self._shutdown_workers()
         await self._close_async_resource(self.session_store, "Redis session store")
         await self._close_async_resource(self.playlist_store, "Redis playlist store")
 
         self.executor.shutdown(wait=True)
+        self.io_executor.shutdown(wait=True)
 
         self._close_sync_resource(self.consumer, "consumer")
         self._close_sync_resource(self.client, "client")

--- a/src/stream_processor/service/device_reset_service.py
+++ b/src/stream_processor/service/device_reset_service.py
@@ -149,6 +149,16 @@ class DeviceResetService:
                 else:
                     logger.info(f"No segments in Redis for {client_id}:{device_id}")
 
+                # Clear the atomic segment counter so numbering restarts cleanly.
+                if not dry_run:
+                    deleted_seq = await self.playlist_store.delete_segment_counter(
+                        client_id, device_id
+                    )
+                    if deleted_seq:
+                        logger.info(
+                            f"Deleted segment counter from Redis for {client_id}:{device_id}"
+                        )
+
             except Exception as e:
                 error_msg = f"Error resetting Redis playlist: {e}"
                 logger.error(error_msg)

--- a/src/stream_processor/service/redis_playlist_store.py
+++ b/src/stream_processor/service/redis_playlist_store.py
@@ -9,6 +9,7 @@ Used by:
 """
 
 import time
+from typing import cast
 from urllib.parse import urlparse
 
 import redis.asyncio as redis
@@ -157,7 +158,7 @@ class RedisPlaylistStore:
             timestamp = time.time()
 
         # ZADD returns 1 if new member added, 0 if score updated
-        added: int = await client.zadd(key, {str(segment_number): timestamp})  # type: ignore[misc]
+        added = cast(int, await client.zadd(key, {str(segment_number): timestamp}))
 
         if added:
             logger.debug(
@@ -268,12 +269,13 @@ class RedisPlaylistStore:
             from_timestamp = to_timestamp - (settings.processing.retention_hours * 3600)
 
         # ZRANGEBYSCORE returns members with scores in range, with scores
-        results = await client.zrangebyscore(  # type: ignore[misc]
-            key, from_timestamp, to_timestamp, withscores=True
+        results = cast(
+            "list[tuple[str, float]]",
+            await client.zrangebyscore(key, from_timestamp, to_timestamp, withscores=True),
         )
 
         # Convert to list of (segment_number, timestamp) tuples
-        segments = [(int(member), score) for member, score in results]
+        segments = [(int(member), float(score)) for member, score in results]
 
         logger.debug(
             f"Retrieved {len(segments)} segments from playlist store: "

--- a/src/stream_processor/service/redis_playlist_store.py
+++ b/src/stream_processor/service/redis_playlist_store.py
@@ -21,6 +21,9 @@ logger = get_logger(__name__)
 # Redis key prefix for segment metadata
 SEGMENTS_KEY_PREFIX = "hls:segments:"
 
+# Redis key prefix for the per-device atomic segment-number counter
+SEQ_KEY_PREFIX = "hls:seq:"
+
 
 class RedisPlaylistStore:
     """
@@ -72,6 +75,59 @@ class RedisPlaylistStore:
     def _segments_key(self, client_id: str, device_id: str) -> str:
         """Get Redis key for segment metadata."""
         return f"{SEGMENTS_KEY_PREFIX}{client_id}:{device_id}"
+
+    def _seq_key(self, client_id: str, device_id: str) -> str:
+        """Get Redis key for the device's segment-number counter."""
+        return f"{SEQ_KEY_PREFIX}{client_id}:{device_id}"
+
+    async def seed_segment_counter(self, client_id: str, device_id: str, first_number: int) -> None:
+        """
+        Seed the per-device segment counter exactly once.
+
+        Stores ``first_number - 1`` so the first :meth:`next_segment_number`
+        call returns ``first_number``. Uses SET NX so it is idempotent and
+        race-free across pods: the first pod to seed wins; any later pod (or a
+        restart) leaves the existing counter untouched and simply continues
+        incrementing from wherever it is.
+
+        Args:
+            client_id: Client identifier
+            device_id: Device identifier
+            first_number: The first segment number this device should use
+                (typically ``highest_existing_segment + 1``, or 0 for a new device).
+        """
+        client = await self.connect()
+        key = self._seq_key(client_id, device_id)
+        # nx=True: only set if the counter does not already exist.
+        await client.set(key, first_number - 1, nx=True)
+
+    async def next_segment_number(self, client_id: str, device_id: str) -> int:
+        """
+        Atomically allocate the next segment number for a device.
+
+        Backed by Redis INCR, so even if two pods briefly process the same
+        device during a Key_Shared rebalance they receive distinct, monotonic
+        numbers — never a collision or an overwritten ``.ts``.
+
+        Returns:
+            The newly allocated segment number.
+        """
+        client = await self.connect()
+        key = self._seq_key(client_id, device_id)
+        value: int = await client.incr(key)  # type: ignore[misc]
+        return value
+
+    async def delete_segment_counter(self, client_id: str, device_id: str) -> bool:
+        """
+        Delete the per-device segment counter (used by device reset).
+
+        Returns:
+            True if the counter existed and was deleted.
+        """
+        client = await self.connect()
+        key = self._seq_key(client_id, device_id)
+        deleted: int = await client.delete(key)
+        return deleted > 0
 
     async def add_segment(
         self,

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -11,6 +11,7 @@ import json
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
+from typing import cast
 
 import redis.asyncio as redis
 from redis.exceptions import WatchError
@@ -156,7 +157,7 @@ class RedisSessionStore:
                 existing = await client.get(key)
 
                 if existing:
-                    session = SessionData.from_json(existing)
+                    session = SessionData.from_json(cast(str, existing))
 
                     # Validate session_id if provided (reject stale updates)
                     if (
@@ -251,7 +252,7 @@ class RedisSessionStore:
                     logger.warning(f"No active session for segment update: {state_key}")
                     return None
 
-                session = SessionData.from_json(existing)
+                session = SessionData.from_json(cast(str, existing))
 
                 # Validate session_id if provided (reject stale updates)
                 if expected_session_id is not None and session.session_id != expected_session_id:
@@ -301,7 +302,7 @@ class RedisSessionStore:
         data = await client.get(key)
 
         if data:
-            return SessionData.from_json(data)
+            return SessionData.from_json(cast(str, data))
         return None
 
     async def get_all_sessions(self) -> list[SessionData]:
@@ -311,7 +312,10 @@ class RedisSessionStore:
         sessions = []
 
         # Get all session keys from index
-        state_keys = await client.smembers(SESSION_INDEX_KEY)  # type: ignore[misc]
+        state_keys = cast(
+            "set[str]",
+            await client.smembers(SESSION_INDEX_KEY),  # type: ignore[misc]
+        )
 
         for state_key in state_keys:
             parts = state_key.split(":", 1)
@@ -385,7 +389,7 @@ class RedisSessionStore:
                 if expected_session_id is not None:
                     existing = await client.get(key)
                     if existing:
-                        current_session = SessionData.from_json(existing)
+                        current_session = SessionData.from_json(cast(str, existing))
                         if current_session.session_id != expected_session_id:
                             await client.unwatch()
                             logger.info(

--- a/src/stream_processor/utils/metrics.py
+++ b/src/stream_processor/utils/metrics.py
@@ -42,6 +42,11 @@ active_devices_gauge = Gauge(
     "Number of currently active devices",
 )
 
+queued_frames_gauge = Gauge(
+    "stream_processor_queued_frames",
+    "Total frames buffered across per-device worker queues awaiting segment generation",
+)
+
 
 # Histograms
 ffmpeg_duration_histogram = Histogram(

--- a/tests/test_consumer_workers.py
+++ b/tests/test_consumer_workers.py
@@ -1,0 +1,150 @@
+"""Tests for the per-device worker model in StreamProcessorConsumer.
+
+These exercise the decoupled consume/generate path directly (no Pulsar broker):
+frames are pushed onto a device's queue and the worker is drained via the same
+graceful-shutdown path used in production.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import stream_processor.consumer.pulsar_consumer as pc
+from stream_processor.model.events import FrameEvent
+from stream_processor.service.redis_playlist_store import RedisPlaylistStore
+
+
+def _make_event(client_id: str, device_id: str, idx: int) -> FrameEvent:
+    """Build a minimal valid FrameEvent."""
+    return FrameEvent(
+        eventId=f"evt-{device_id}-{idx}",
+        clientId=client_id,
+        deviceId=device_id,
+        timestamp=datetime.now(UTC),
+        framePath=f"/frames/{device_id}/{idx}.jpg",
+        requestId=f"req-{device_id}-{idx}",
+    )
+
+
+def _make_consumer(monkeypatch, gen_side_effect, highest=-1):
+    """Construct a consumer with a mocked HLS generator (no filesystem/FFmpeg)."""
+    fake_hls = MagicMock()
+    fake_hls.get_highest_segment_number.return_value = highest
+    fake_hls.generate_segment.side_effect = gen_side_effect
+    # Patch the class so __init__ does not build a real (mkdir-ing) generator.
+    monkeypatch.setattr(pc, "HLSGenerator", lambda: fake_hls)
+    consumer = pc.StreamProcessorConsumer(use_redis=False)
+    consumer.running = True
+    return consumer, fake_hls
+
+
+def _shutdown_executors(consumer) -> None:
+    consumer.executor.shutdown(wait=False)
+    consumer.io_executor.shutdown(wait=False)
+
+
+class TestPerDeviceWorker:
+    """Core decoupled generation behavior."""
+
+    async def test_generates_one_segment_at_frame_threshold(self, monkeypatch):
+        """Pushing frames_per_segment frames triggers exactly one generation."""
+        calls: list[tuple] = []
+
+        def gen(client_id, device_id, frames, segment_number, offset):
+            calls.append((device_id, list(frames), segment_number))
+            return (f"seg_{segment_number:06d}.ts", float(len(frames)))
+
+        consumer, _ = _make_consumer(monkeypatch, gen)
+        try:
+            fps = consumer.processing_config.frames_per_segment
+            queue = consumer._get_or_create_worker("c:d", "c", "d")
+            for i in range(fps):
+                await queue.put(_make_event("c", "d", i))
+
+            # Drains the queue, then flushes & exits each worker deterministically.
+            await consumer._shutdown_workers()
+
+            assert len(calls) == 1
+            device_id, frames, segment_number = calls[0]
+            assert device_id == "d"
+            assert len(frames) == fps
+            assert segment_number == 0  # seeded from highest=-1
+        finally:
+            _shutdown_executors(consumer)
+
+    async def test_two_devices_number_independently(self, monkeypatch):
+        """Each device gets its own worker and its own segment numbering."""
+        calls: list[tuple] = []
+
+        def gen(client_id, device_id, frames, segment_number, offset):
+            calls.append((device_id, segment_number))
+            return (f"seg_{segment_number:06d}.ts", float(len(frames)))
+
+        consumer, _ = _make_consumer(monkeypatch, gen)
+        try:
+            fps = consumer.processing_config.frames_per_segment
+            qa = consumer._get_or_create_worker("c:a", "c", "a")
+            qb = consumer._get_or_create_worker("c:b", "c", "b")
+            for i in range(fps):
+                await qa.put(_make_event("c", "a", i))
+                await qb.put(_make_event("c", "b", i))
+
+            await consumer._shutdown_workers()
+
+            assert len(consumer.device_states) == 2
+            by_device = dict(calls)
+            assert by_device == {"a": 0, "b": 0}
+        finally:
+            _shutdown_executors(consumer)
+
+    async def test_partial_frames_flushed_on_shutdown(self, monkeypatch):
+        """Frames below threshold are flushed into a segment on graceful stop."""
+        calls: list[tuple] = []
+
+        def gen(client_id, device_id, frames, segment_number, offset):
+            calls.append((device_id, list(frames), segment_number))
+            return (f"seg_{segment_number:06d}.ts", float(len(frames)))
+
+        consumer, _ = _make_consumer(monkeypatch, gen)
+        try:
+            queue = consumer._get_or_create_worker("c:d", "c", "d")
+            # Three frames: below the default threshold of 6.
+            for i in range(3):
+                await queue.put(_make_event("c", "d", i))
+
+            await consumer._shutdown_workers()
+
+            assert len(calls) == 1
+            assert len(calls[0][1]) == 3
+        finally:
+            _shutdown_executors(consumer)
+
+    async def test_redis_segment_counter_allocates_number(self, monkeypatch, fake_redis):
+        """When enabled, the segment number comes from the atomic Redis counter."""
+        calls: list[tuple] = []
+
+        def gen(client_id, device_id, frames, segment_number, offset):
+            calls.append((device_id, segment_number))
+            return (f"seg_{segment_number:06d}.ts", float(len(frames)))
+
+        consumer, _ = _make_consumer(monkeypatch, gen, highest=-1)
+        try:
+            # Wire a Redis-backed counter and pre-seed it to a distinctive value
+            # so the result can only come from Redis (in-memory would be 0).
+            store = RedisPlaylistStore()
+            store._client = fake_redis
+            consumer.playlist_store = store
+            consumer.segment_counter_enabled = True
+            await fake_redis.set("hls:seq:c:d", 41)  # next INCR -> 42
+
+            fps = consumer.processing_config.frames_per_segment
+            queue = consumer._get_or_create_worker("c:d", "c", "d")
+            for i in range(fps):
+                await queue.put(_make_event("c", "d", i))
+
+            await consumer._shutdown_workers()
+
+            assert len(calls) == 1
+            assert calls[0][1] == 42
+        finally:
+            _shutdown_executors(consumer)
+            await fake_redis.flushall()

--- a/tests/test_redis_playlist_store.py
+++ b/tests/test_redis_playlist_store.py
@@ -2,8 +2,6 @@
 
 import time
 
-import pytest
-
 
 class TestRedisPlaylistStoreAddSegment:
     """Tests for add_segment method."""
@@ -52,9 +50,7 @@ class TestRedisPlaylistStoreAddSegment:
         assert segment_num == 100
         assert before <= timestamp <= after
 
-    async def test_add_multiple_segments(
-        self, playlist_store, sample_client_id, sample_device_id
-    ):
+    async def test_add_multiple_segments(self, playlist_store, sample_client_id, sample_device_id):
         """Test adding multiple segments."""
         await playlist_store.add_segment(
             sample_client_id, sample_device_id, segment_number=100, timestamp=1705574400
@@ -387,9 +383,7 @@ class TestRedisPlaylistStoreDeletePlaylist:
 class TestRedisPlaylistStoreMultipleDevices:
     """Tests for multiple devices/clients."""
 
-    async def test_segments_isolated_between_devices(
-        self, playlist_store, sample_client_id
-    ):
+    async def test_segments_isolated_between_devices(self, playlist_store, sample_client_id):
         """Test that segments are isolated between different devices."""
         device1 = "device-001"
         device2 = "device-002"
@@ -424,9 +418,7 @@ class TestRedisPlaylistStoreMultipleDevices:
         assert segments1[0][0] == 100
         assert segments2[0][0] == 200
 
-    async def test_segments_isolated_between_clients(
-        self, playlist_store, sample_device_id
-    ):
+    async def test_segments_isolated_between_clients(self, playlist_store, sample_device_id):
         """Test that segments are isolated between different clients."""
         client1 = "client-001"
         client2 = "client-002"
@@ -466,6 +458,75 @@ class TestRedisPlaylistStoreMultipleDevices:
         # Verify device1 is empty but device2 is intact
         assert await playlist_store.get_segment_count(sample_client_id, device1) == 0
         assert await playlist_store.get_segment_count(sample_client_id, device2) == 1
+
+
+class TestRedisPlaylistStoreSegmentCounter:
+    """Tests for the atomic per-device segment counter."""
+
+    async def test_seed_then_next_returns_first_number(
+        self, playlist_store, sample_client_id, sample_device_id
+    ):
+        """First allocation after seeding returns exactly the seeded first number."""
+        await playlist_store.seed_segment_counter(sample_client_id, sample_device_id, 100)
+
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 100
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 101
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 102
+
+    async def test_seed_from_zero(self, playlist_store, sample_client_id, sample_device_id):
+        """A brand-new device seeded at 0 starts numbering at 0."""
+        await playlist_store.seed_segment_counter(sample_client_id, sample_device_id, 0)
+
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 0
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 1
+
+    async def test_seed_is_idempotent(self, playlist_store, sample_client_id, sample_device_id):
+        """Re-seeding (e.g. a second pod) never rewinds an existing counter."""
+        await playlist_store.seed_segment_counter(sample_client_id, sample_device_id, 100)
+        await playlist_store.next_segment_number(sample_client_id, sample_device_id)  # -> 100
+
+        # A second pod seeds with a stale value; SET NX must leave the counter alone.
+        await playlist_store.seed_segment_counter(sample_client_id, sample_device_id, 100)
+
+        # Continues from where it was, not from the re-seeded value.
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 101
+
+    async def test_next_without_seed_starts_at_one(
+        self, playlist_store, sample_client_id, sample_device_id
+    ):
+        """INCR on a missing key starts at 1 (counter used without seeding)."""
+        assert await playlist_store.next_segment_number(sample_client_id, sample_device_id) == 1
+
+    async def test_counter_isolated_between_devices(self, playlist_store, sample_client_id):
+        """Each device has an independent counter."""
+        await playlist_store.seed_segment_counter(sample_client_id, "device-a", 10)
+        await playlist_store.seed_segment_counter(sample_client_id, "device-b", 500)
+
+        assert await playlist_store.next_segment_number(sample_client_id, "device-a") == 10
+        assert await playlist_store.next_segment_number(sample_client_id, "device-b") == 500
+        assert await playlist_store.next_segment_number(sample_client_id, "device-a") == 11
+
+    async def test_delete_segment_counter(self, playlist_store, sample_client_id, sample_device_id):
+        """Deleting the counter resets numbering on next use."""
+        await playlist_store.seed_segment_counter(sample_client_id, sample_device_id, 100)
+        await playlist_store.next_segment_number(sample_client_id, sample_device_id)
+
+        assert (
+            await playlist_store.delete_segment_counter(sample_client_id, sample_device_id) is True
+        )
+        # Deleting a missing counter returns False.
+        assert (
+            await playlist_store.delete_segment_counter(sample_client_id, sample_device_id) is False
+        )
+
+    async def test_seq_key_format(
+        self, playlist_store, fake_redis, sample_client_id, sample_device_id
+    ):
+        """The counter Redis key uses the expected hls:seq: prefix."""
+        await playlist_store.seed_segment_counter(sample_client_id, sample_device_id, 5)
+
+        expected_key = f"hls:seq:{sample_client_id}:{sample_device_id}"
+        assert await fake_redis.exists(expected_key) == 1
 
 
 class TestRedisPlaylistStoreKeyFormat:


### PR DESCRIPTION
Closes #17

## Problem

Under load the processor falls behind — 35K+ frames queued and the real-time HLS view is lost while the backlog drains. Although a 50-worker FFmpeg pool is configured, the receive loop **awaited each segment generation before pulling the next message**, so effective concurrency was **1 FFmpeg at a time**. The blocking `consumer.receive()` also ran directly on the event loop.

## What changed

**Tier 0 — decouple consumption from generation (per-device worker model).**
- Receive loop only parses → routes each frame to a per-device `asyncio.Queue` → acks. Blocking `receive()` moved to a dedicated IO thread.
- One worker task per device drains its queue and generates that device's segments **serially** (ordering + per-session PTS preserved); **different devices run concurrently**, bounded by `MAX_WORKERS`. Effective concurrency: **1 → min(active devices, MAX_WORKERS)**.
- Bounded per-device queues (`PROCESSING_DEVICE_QUEUE_MAXSIZE`) give end-to-end backpressure instead of unbounded memory growth on a backlog.
- Replaces the per-device locks + global segment timer with the worker loop.

**Multi-pod hardening — atomic Redis segment counter.**
- `REDIS_SEGMENT_COUNTER_ENABLED` allocates segment numbers via `INCR hls:seq:{client}:{device}` (seeded from storage), keeping per-device numbering collision-free across the Key_Shared rebalance window. Falls back to in-memory numbering when disabled/unavailable. Device reset clears it.

**Observability:** new `stream_processor_queued_frames` gauge for the live backlog.

## New configuration

| Variable | Default | Purpose |
|---|---|---|
| `PROCESSING_DEVICE_QUEUE_MAXSIZE` | 256 | Per-device backpressure bound |
| `PROCESSING_SEGMENT_TIMER_INTERVAL_SECONDS` | 10 | Idle flush cadence |
| `REDIS_SEGMENT_COUNTER_ENABLED` | false | Atomic cross-pod segment numbering |

## Rollout

1. **Single pod now:** deploy and set `PROCESSING_MAX_WORKERS` near the pod's **vCPU count** (FFmpeg is CPU-bound). This alone should drain the backlog and restore the live edge.
2. **Scale pods** for more throughput, enabling `REDIS_SEGMENT_COUNTER_ENABLED=true` first.

> ⚠️ **Prerequisite for >1 pod:** the publisher (`quarkus-http-pulsar-publisher`) must set the Pulsar message **key** to the device so Key_Shared pins each device to one consumer. Not verifiable from this repo — confirm before scaling out.

## Testing

- `ruff`, `black`, `mypy` clean on changed code (remaining mypy items are pre-existing: `add_segment`/`get_segments` typing and the unavoidable `pulsar` import-untyped).
- 46 tests pass, including:
  - 4 new worker-model tests (threshold generation, per-device independence, shutdown flush, Redis numbering).
  - 7 new Redis segment-counter tests (seed/incr/idempotent/delete/isolation).

## Out of scope (follow-ups)

- Tier 1 per-segment cost cuts: drop the `ffprobe` subprocess, fold the watermark into the single encode, stop full-rebuilding the rolling playlist each segment.
- Tier 3: split live vs. backlog lanes so a future surge can't starve the real-time edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Optional Redis-backed segment numbering for multi-pod deployments to prevent collisions during rebalancing
  * New backlog metric to monitor frames buffered in per-device queues
  * New configuration options for queue buffer size and segment flushing intervals

* **Documentation**
  * Updated architecture documentation with concurrency model explanation and segment numbering details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->