### PR TITLE
feat: batch Pulsar receive for higher consumer intake throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ end-to-end backpressure: when a device's queue fills, the receive loop stops
 pulling from Pulsar (which stops the broker delivering) instead of buffering
 frames unbounded in memory.
 
+The consumer pulls from Pulsar with **batch receive** so intake isn't capped at
+one receive round-trip per message — important when draining a backlog.
+`PROCESSING_RECEIVE_BATCH_SIZE` (messages per batch) and
+`PROCESSING_RECEIVE_BATCH_TIMEOUT_MS` (max wait to fill a batch) tune it without
+a code change.
+
 ### Segment numbering across pods
 
 Key_Shared pins each device to a single pod, so per-device segment numbering is

--- a/env.example
+++ b/env.example
@@ -35,6 +35,11 @@ PROCESSING_VIDEO_WIDTH=1920
 PROCESSING_DEVICE_QUEUE_MAXSIZE=256
 # How often an idle device worker wakes to flush a time-based segment.
 PROCESSING_SEGMENT_TIMER_INTERVAL_SECONDS=10
+# Pulsar batch receive: messages pulled per batch_receive() call. Raise to lift
+# consumer intake throughput when draining a backlog (fewer receive round-trips).
+PROCESSING_RECEIVE_BATCH_SIZE=100
+# Max time (ms) batch_receive() waits to fill a batch before returning.
+PROCESSING_RECEIVE_BATCH_TIMEOUT_MS=100
 
 # Redis Configuration (REQUIRED for offline detection with separate checker service)
 # Consumer writes session state to Redis, offline-checker reads it

--- a/src/stream_processor/config/settings.py
+++ b/src/stream_processor/config/settings.py
@@ -72,6 +72,22 @@ class ProcessingConfig(BaseSettings):
             "when frames arrive sporadically (no new frame for max_segment_wait_seconds)."
         ),
     )
+    receive_batch_size: int = Field(
+        default=100,
+        description=(
+            "Max Pulsar messages pulled per batch_receive() call. Higher values "
+            "raise consumer intake throughput when draining a backlog (fewer "
+            "receive round-trips per message). Tune with PROCESSING_RECEIVE_BATCH_SIZE."
+        ),
+    )
+    receive_batch_timeout_ms: int = Field(
+        default=100,
+        description=(
+            "Max time batch_receive() waits to fill a batch before returning what "
+            "it has. Lower = lower latency when traffic is light; higher = larger "
+            "batches under load."
+        ),
+    )
     frame_interval_seconds: int = Field(
         default=1, description="Display duration per frame in output video"
     )

--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -358,13 +358,19 @@ class StreamProcessorConsumer:
             processing_errors_total.labels(device_id=state_key, error_type="ffmpeg").inc()
             logger.error(f"Failed to generate segment for {state_key}: {e}", exc_info=True)
 
-    def _blocking_receive(self) -> pulsar.Message | None:
-        """Blocking Pulsar receive, run on the dedicated io thread."""
+    def _blocking_batch_receive(self) -> list[pulsar.Message]:
+        """
+        Blocking batch receive, run on the dedicated io thread.
+
+        Returns up to receive_batch_size messages (fewer if the batch timeout
+        elapses first), or an empty list on timeout. Batching keeps consumer
+        intake from being capped at one receive round-trip per message.
+        """
         assert self.consumer is not None
         try:
-            return self.consumer.receive(timeout_millis=1000)
+            return list(self.consumer.batch_receive())
         except pulsar.Timeout:
-            return None
+            return []
 
     async def _dispatch(self, msg: pulsar.Message) -> None:
         """Parse a Pulsar message, route the frame to its device worker, and ack."""
@@ -420,6 +426,10 @@ class StreamProcessorConsumer:
         logger.info(f"Subscription: {self.config.subscription}")
         logger.info(f"Max Workers: {self.processing_config.max_workers}")
         logger.info(f"Device queue maxsize: {self.processing_config.device_queue_maxsize}")
+        logger.info(
+            f"Receive batch: size={self.processing_config.receive_batch_size} "
+            f"timeout_ms={self.processing_config.receive_batch_timeout_ms}"
+        )
         logger.info(f"Redis session tracking: {'enabled' if self.session_store else 'disabled'}")
         logger.info(f"Redis playlist store: {'enabled' if self.playlist_enabled else 'disabled'}")
         logger.info(
@@ -454,13 +464,23 @@ class StreamProcessorConsumer:
             )
             assert self.client is not None  # For type checker
 
+            # Pull messages in batches so intake isn't capped by one receive
+            # round-trip per message. The batch completes as soon as ANY of:
+            # batch_size messages, ~10MB, or batch_timeout_ms elapsed.
+            batch_policy = pulsar.ConsumerBatchReceivePolicy(
+                self.processing_config.receive_batch_size,
+                10 * 1024 * 1024,
+                self.processing_config.receive_batch_timeout_ms,
+            )
+
             # Create consumer with Key_Shared subscription
             self.consumer = self.client.subscribe(
                 self.config.topic,
                 subscription_name=self.config.subscription,
                 consumer_type=pulsar.ConsumerType.KeyShared,
                 consumer_name=self.config.consumer_name,
-                receiver_queue_size=1000,
+                receiver_queue_size=max(1000, self.processing_config.receive_batch_size * 2),
+                batch_receive_policy=batch_policy,
             )
 
             logger.info("Connected to Pulsar broker")
@@ -471,18 +491,20 @@ class StreamProcessorConsumer:
             # Start background metrics task
             metrics_task = asyncio.create_task(self._update_metrics_loop())
 
-            # Main receive loop: receive (off the event loop) -> dispatch -> ack.
-            # Segment generation happens in per-device workers, not here.
+            # Main receive loop: batch-receive (off the event loop) -> dispatch
+            # each in order -> ack. Segment generation happens in per-device
+            # workers, not here.
             loop = asyncio.get_event_loop()
             while self.running:
                 try:
-                    msg = await loop.run_in_executor(self.io_executor, self._blocking_receive)
-                    if msg is None:
-                        continue
-                    await self._dispatch(msg)
+                    msgs = await loop.run_in_executor(
+                        self.io_executor, self._blocking_batch_receive
+                    )
+                    for msg in msgs:
+                        await self._dispatch(msg)
                 except Exception as e:
                     if self.running:
-                        logger.error(f"Error receiving message: {e}")
+                        logger.error(f"Error receiving messages: {e}")
                         await asyncio.sleep(1)
 
             # Cancel background tasks

--- a/tests/test_consumer_workers.py
+++ b/tests/test_consumer_workers.py
@@ -5,8 +5,11 @@ frames are pushed onto a device's queue and the worker is drained via the same
 graceful-shutdown path used in production.
 """
 
+import json
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
+
+import pulsar
 
 import stream_processor.consumer.pulsar_consumer as pc
 from stream_processor.model.events import FrameEvent
@@ -148,3 +151,70 @@ class TestPerDeviceWorker:
         finally:
             _shutdown_executors(consumer)
             await fake_redis.flushall()
+
+
+def _pulsar_msg(client_id: str, device_id: str, idx: int):
+    """A fake Pulsar message whose .data() is a valid FrameEvent JSON."""
+    m = MagicMock()
+    m.data.return_value = json.dumps(
+        {
+            "eventId": f"e-{device_id}-{idx}",
+            "clientId": client_id,
+            "deviceId": device_id,
+            "timestamp": "2025-11-25T10:30:00Z",
+            "framePath": f"/frames/{device_id}/{idx}.jpg",
+            "requestId": f"r-{device_id}-{idx}",
+        }
+    ).encode()
+    return m
+
+
+class TestBatchReceive:
+    """The batched Pulsar intake path."""
+
+    def test_blocking_batch_receive_returns_list(self, monkeypatch):
+        """batch_receive results are returned as a plain list."""
+        consumer, _ = _make_consumer(monkeypatch, lambda *a: ("u", 1.0))
+        try:
+            m1, m2 = object(), object()
+            fake = MagicMock()
+            fake.batch_receive.return_value = [m1, m2]
+            consumer.consumer = fake
+            assert consumer._blocking_batch_receive() == [m1, m2]
+        finally:
+            _shutdown_executors(consumer)
+
+    def test_blocking_batch_receive_timeout_returns_empty(self, monkeypatch):
+        """A batch timeout yields an empty list, not an exception."""
+        consumer, _ = _make_consumer(monkeypatch, lambda *a: ("u", 1.0))
+        try:
+            fake = MagicMock()
+            fake.batch_receive.side_effect = pulsar.Timeout
+            consumer.consumer = fake
+            assert consumer._blocking_batch_receive() == []
+        finally:
+            _shutdown_executors(consumer)
+
+    async def test_dispatch_batch_routes_and_acks(self, monkeypatch):
+        """Each message in a batch is routed to its device worker and acked."""
+        calls: list[tuple] = []
+
+        def gen(client_id, device_id, frames, segment_number, offset):
+            calls.append((device_id, segment_number))
+            return (f"seg_{segment_number:06d}.ts", float(len(frames)))
+
+        consumer, _ = _make_consumer(monkeypatch, gen)
+        consumer.consumer = MagicMock()  # for acknowledge()
+        try:
+            fps = consumer.processing_config.frames_per_segment
+            # Interleave two devices, fps frames each — mimics a batch.
+            for i in range(fps):
+                await consumer._dispatch(_pulsar_msg("c", "a", i))
+                await consumer._dispatch(_pulsar_msg("c", "b", i))
+
+            await consumer._shutdown_workers()
+
+            assert consumer.consumer.acknowledge.call_count == fps * 2
+            assert {d for d, _ in calls} == {"a", "b"}
+        finally:
+            _shutdown_executors(consumer)


### PR DESCRIPTION
Closes #20

## Problem

After the per-device concurrency work (PR #18) shipped, live diagnosis on prod showed the consumer draining the Pulsar backlog at only **~8 msg/s** while using **1.6 of 8 vCPU** — FFmpeg concurrency ~0.7. The bottleneck moved upstream of FFmpeg: the receive loop pulled **one message per `receive()` round-trip** (each offloaded to a single IO thread), capping intake at ~8–10 msg/s regardless of how many workers/cores were available. A 92K backlog was draining at ~3/s net → ~8h ETA.

## What changed

- Subscribe with a `ConsumerBatchReceivePolicy` and pull via **`consumer.batch_receive()`** instead of one-at-a-time `receive()`. Each pull returns up to `PROCESSING_RECEIVE_BATCH_SIZE` messages (default **100**) or whatever arrived within `PROCESSING_RECEIVE_BATCH_TIMEOUT_MS` (default **100ms**), then dispatches each in order (routing + ack unchanged).
- `receiver_queue_size` now scales with the batch size (`max(1000, batch_size*2)`).
- Both knobs are **env vars** for tuning without a redeploy:
  - `PROCESSING_RECEIVE_BATCH_SIZE`
  - `PROCESSING_RECEIVE_BATCH_TIMEOUT_MS`

Ordering is preserved: Key_Shared keeps per-device order within and across batches, and messages are dispatched sequentially.

## Why this is the right next lever

Parallelism is per-device; the workers/CPU were idle because the **feeder** couldn't keep them fed. Lifting intake from ~8/s to batches of ~100/pull lets the 16 workers / 8 vCPU actually engage and the backlog drain at the FFmpeg rate.

## Testing

- `ruff`, `black`, `mypy src/ --ignore-missing-imports` clean.
- 49 tests pass (+3): `_blocking_batch_receive` returns a list / empty on timeout, and a batch of interleaved two-device messages routes to per-device workers with one ack each.

## Rollout / measurement

After merge + image build, bump the Helm `image.tag` (single-pod values already set `MAX_WORKERS=16` / 8 vCPU). Watch:
- Pulsar subscription backlog + `msgRateOut` (should jump well past ~8/s),
- consumer CPU (should climb toward 8 if enough devices are active),
- `stream_processor_segments_generated_total` rate.

If intake rises but CPU still doesn't, the remaining limit is **distinct device count** in the backlog (per-device-serial floor) — the next investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled batch message receiving to improve consumer throughput when processing message backlogs.
  * Added configurable batch size and timeout parameters for fine-tuning message intake rates.

* **Documentation**
  * Updated README with batch receiving configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->