### PR TITLE
fix: make consumer shut down cleanly on Ctrl-C

### DIFF
--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -501,6 +501,11 @@ class StreamProcessorConsumer:
                         self.io_executor, self._blocking_batch_receive
                     )
                     for msg in msgs:
+                        # Stop mid-batch on shutdown so we don't re-create workers
+                        # or block on a full queue after stop() has run. Undispatched
+                        # messages are unacked and redelivered by Pulsar.
+                        if not self.running:
+                            break
                         await self._dispatch(msg)
                 except Exception as e:
                     if self.running:

--- a/src/stream_processor/main.py
+++ b/src/stream_processor/main.py
@@ -10,6 +10,7 @@ Main entry points for the stream processor services:
 
 import argparse
 import asyncio
+import os
 import signal
 import sys
 
@@ -169,9 +170,22 @@ def run_consumer(use_redis: bool = True) -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
+    shutdown_state = {"count": 0}
+
     def shutdown_handler(sig: signal.Signals) -> None:
-        logger.info(f"Received {sig.name}, initiating shutdown...")
-        loop.create_task(consumer.stop())
+        # First signal: request a single graceful shutdown by flipping the run
+        # loop's flag — run()'s own finally calls stop() exactly once. Do NOT
+        # spawn stop() here: a concurrent stop() races the still-running receive
+        # loop (which would re-create workers) and never converges.
+        shutdown_state["count"] += 1
+        if shutdown_state["count"] == 1:
+            logger.info(
+                f"Received {sig.name}, shutting down gracefully (press Ctrl-C again to force)..."
+            )
+            consumer.running = False
+        else:
+            logger.warning(f"Received {sig.name} again — forcing immediate exit")
+            os._exit(130)
 
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, shutdown_handler, sig)


### PR DESCRIPTION
Closes #21

## Problem
Ctrl-C didn't return control: the SIGINT/SIGTERM handler spawned a fresh `consumer.stop()` task on every signal, racing the still-running receive loop (which re-created per-device workers) while its blocking `executor.shutdown(wait=True)` froze the event loop. Shutdown never converged.

## Fix
- **Signal handler** now sets `consumer.running = False` for one graceful shutdown — `run()`'s `finally` calls `stop()` exactly once. A second signal forces `os._exit(130)`.
- **Receive loop** breaks mid-batch once `running` flips, so it can't re-create workers or block on `queue.put` after `stop()`. Undispatched messages stay unacked and are redelivered by Pulsar.

## Testing
- ruff / black / mypy (`--ignore-missing-imports`) clean; 49 tests pass.
- Manually: one Ctrl-C returns the shell; a second force-exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)