### PR TITLE
feat: order playlist segments by content time (parallel-safe)

### DIFF
--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -292,13 +292,27 @@ class StreamProcessorConsumer:
         return state.current_segment_number
 
     async def _add_segment_to_playlist(
-        self, client_id: str, device_id: str, segment_number: int
+        self,
+        client_id: str,
+        device_id: str,
+        segment_number: int,
+        timestamp: float | None = None,
     ) -> None:
-        """Add segment to playlist store in Redis for dynamic playlist generation."""
+        """Add segment to playlist store in Redis for dynamic playlist generation.
+
+        ``timestamp`` is the segment's first-frame capture time (epoch seconds),
+        used as the ZSET score so the playlist orders by content time — correct
+        even if segments are generated out of order (parallel catch-up). The
+        quarkus playlist reads this ordering and the cleanup service uses it for
+        time-based retention, so a content timestamp satisfies both. Falls back
+        to "now" when unavailable.
+        """
         if not (self.playlist_store and self.playlist_enabled):
             return
         try:
-            await self.playlist_store.add_segment(client_id, device_id, segment_number)
+            await self.playlist_store.add_segment(
+                client_id, device_id, segment_number, timestamp=timestamp
+            )
         except Exception as e:
             logger.warning(
                 f"Failed to add segment to playlist store "
@@ -315,6 +329,14 @@ class StreamProcessorConsumer:
         if not frames:
             logger.warning(f"No frames to process for {state_key}")
             return
+
+        # Capture the segment's content timestamp before clear_pending_frames()
+        # resets it; used as the playlist-store score (content-time ordering).
+        segment_score = (
+            state.pending_first_frame_time.timestamp()
+            if state.pending_first_frame_time is not None
+            else None
+        )
 
         segment_number = await self._next_segment_number(state)
 
@@ -350,7 +372,9 @@ class StreamProcessorConsumer:
                 if self.session_store:
                     await self.session_store.update_segment(client_id, device_id, segment_number)
 
-                await self._add_segment_to_playlist(client_id, device_id, segment_number)
+                await self._add_segment_to_playlist(
+                    client_id, device_id, segment_number, segment_score
+                )
             else:
                 logger.debug(f"Segment generation skipped for {state_key} (missing frames)")
 

--- a/src/stream_processor/model/events.py
+++ b/src/stream_processor/model/events.py
@@ -54,6 +54,14 @@ class DeviceState(BaseModel):
     device_id: str = Field(description="Device identifier")
     frame_count: int = Field(default=0, description="Accumulated frames since last segment")
     last_frame_time: datetime | None = Field(default=None, description="Last frame timestamp")
+    pending_first_frame_time: datetime | None = Field(
+        default=None,
+        description=(
+            "Capture timestamp of the first frame in the current pending batch. "
+            "Used as the playlist-store score so segments order by content time "
+            "(safe for parallel/out-of-order generation) rather than generation time."
+        ),
+    )
     last_segment_time: datetime | None = Field(
         default=None, description="Last segment generation time"
     )
@@ -80,6 +88,8 @@ class DeviceState(BaseModel):
 
     def add_frame(self, frame_path: str, timestamp: datetime) -> None:
         """Add a frame to pending frames."""
+        if not self.pending_frames:
+            self.pending_first_frame_time = timestamp
         self.pending_frames.append(frame_path)
         self.frame_count = len(self.pending_frames)
         self.last_frame_time = timestamp
@@ -88,6 +98,7 @@ class DeviceState(BaseModel):
         """Clear and return pending frames after segment generation."""
         frames = self.pending_frames.copy()
         self.pending_frames = []
+        self.pending_first_frame_time = None
         self.frame_count = 0
         self.current_segment_number += 1
         self.last_segment_time = datetime.now(UTC)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -81,6 +81,32 @@ class TestDeviceState:
         assert len(state.pending_frames) == 0
         assert state.current_segment_number == 1
 
+    def test_pending_first_frame_time_tracks_batch_start(self):
+        """First-frame time is set on the first frame and held for the batch."""
+        state = DeviceState(client_id="c", device_id="d")
+        t0 = datetime.now(UTC)
+        t1 = t0 + timedelta(seconds=1)
+
+        assert state.pending_first_frame_time is None
+        state.add_frame("/f0.jpg", t0)
+        assert state.pending_first_frame_time == t0
+        # Later frames in the same batch must not move the batch-start time.
+        state.add_frame("/f1.jpg", t1)
+        assert state.pending_first_frame_time == t0
+
+    def test_pending_first_frame_time_resets_per_segment(self):
+        """Clearing resets the batch-start time so the next batch tracks fresh."""
+        state = DeviceState(client_id="c", device_id="d")
+        t0 = datetime.now(UTC)
+        t_next = t0 + timedelta(seconds=6)
+
+        state.add_frame("/f0.jpg", t0)
+        state.clear_pending_frames()
+        assert state.pending_first_frame_time is None
+
+        state.add_frame("/f6.jpg", t_next)
+        assert state.pending_first_frame_time == t_next
+
     def test_should_generate_segment_by_count(self):
         """Test segment generation trigger by frame count."""
         state = DeviceState(client_id="test-client", device_id="test-device")


### PR DESCRIPTION
Part 1 of #23 — prerequisite for the HLS-muxer catch-up path.

## Why
`RedisPlaylistService` builds the live playlist from the Redis ZSET ordered by **score** and derives `EXT-X-MEDIA-SEQUENCE` from the first member. The consumer wrote score = `time.time()`, which only matches segment order while generation is **serial**. Parallel/out-of-order generation would scramble the live window.

## Change
Use the segment's **first-frame capture timestamp** as the ZSET score:
- `DeviceState.pending_first_frame_time` (set on a batch's first frame, reset on clear).
- `_generate_segment` captures it before clearing and passes it to `add_segment(timestamp=...)`.

Ordering is now content-time based — correct regardless of completion order. Score stays a timestamp, so cleanup's time-retention still works (now on content age). **No quarkus change needed.**

## Testing
- ruff/black/mypy clean; 51 tests pass (+2 for first-frame tracking).
- Compatibility of the muxer path itself proven by a local prototype (see #23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic playlist generation now correctly orders content by capture time, ensuring accurate and consistent sequencing even when segments are processed out of order or in parallel. This enhancement significantly improves overall system reliability and user experience.

* **Tests**
  * Added tests to verify proper timestamp tracking behavior during content batching and frame clearing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->