### PR TITLE
perf: watermark to local temp instead of GCS re-upload

### DIFF
--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -381,6 +381,10 @@ class StreamProcessorConsumer:
         except Exception as e:
             processing_errors_total.labels(device_id=state_key, error_type="ffmpeg").inc()
             logger.error(f"Failed to generate segment for {state_key}: {e}", exc_info=True)
+        finally:
+            # Remove watermarked temp frames now that FFmpeg has consumed them.
+            if self.watermark_service:
+                self.watermark_service.cleanup_temp_frames(frames)
 
     def _blocking_batch_receive(self) -> list[pulsar.Message]:
         """

--- a/src/stream_processor/service/watermark_service.py
+++ b/src/stream_processor/service/watermark_service.py
@@ -4,6 +4,7 @@ Watermark service for adding timestamp overlays to video frames.
 
 import asyncio
 import tempfile
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -26,6 +27,25 @@ class WatermarkService:
             gcs_bucket=settings.storage.gcs_bucket,
             gcs_project_id=settings.storage.gcs_project_id,
         )
+        # Dedicated dir for watermarked GCS frames. We write the watermarked image
+        # to a local temp here and hand FFmpeg that path directly, instead of
+        # re-uploading to GCS and re-downloading in the encoder. The consumer
+        # deletes these after the segment is generated.
+        self.wm_dir = Path(tempfile.gettempdir()) / "stream_wm"
+        self.wm_dir.mkdir(parents=True, exist_ok=True)
+
+    def is_watermark_temp(self, path: str) -> bool:
+        """True if path is a watermarked temp this service produced (safe to delete)."""
+        return not path.startswith("gs://") and path.startswith(str(self.wm_dir))
+
+    def cleanup_temp_frames(self, paths: list[str]) -> None:
+        """Delete watermarked temp frames (no-op for originals / GCS URIs)."""
+        for path in paths:
+            if self.is_watermark_temp(path):
+                try:
+                    Path(path).unlink(missing_ok=True)
+                except OSError:
+                    pass
 
     def _get_font(self, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
         """Get font for watermark text."""
@@ -162,50 +182,21 @@ class WatermarkService:
 
         # Open image with context manager to ensure proper cleanup
         with Image.open(frame_path) as image:
-            # Create drawing context
-            draw = ImageDraw.Draw(image, mode="RGBA")
-
-            # Get font
-            font = self._get_font(self.config.font_size)
-
-            # Format timestamp text
-            text = self._format_timestamp(timestamp)
-
-            # Get text bounding box
-            text_bbox = draw.textbbox((0, 0), text, font=font)
-            text_width = text_bbox[2] - text_bbox[0]
-            text_height = text_bbox[3] - text_bbox[1]
-
-            # Calculate position
-            x, y = self._get_position(image.width, image.height, text_bbox)
-
-            # Draw semi-transparent background
-            bg_padding = 5
-            bg_rect = [
-                x - bg_padding,
-                y - bg_padding,
-                x + text_width + bg_padding,
-                y + text_height + bg_padding,
-            ]
-            draw.rectangle(bg_rect, fill=(0, 0, 0, 204))  # 80% opacity black
-
-            # Draw white text
-            draw.text((x, y), text, fill=(255, 255, 255, 255), font=font)
-
-            # Save image
+            self._draw_watermark(image, timestamp)
             image.save(output_path, quality=95)
 
         return str(output_path)
 
     def _add_watermark_gcs(self, gcs_path: str, timestamp: datetime) -> str:
         """
-        Apply watermark to a GCS-stored frame.
+        Apply a watermark to a GCS-stored frame and return a LOCAL temp path.
 
-        Downloads the frame, applies watermark, uploads the watermarked bytes back
-        to the same GCS object (replacing the original), and returns the original
-        GCS URI. Downstream consumers (hls_generator) will pull the watermarked
-        content from GCS into a managed temp directory whose lifecycle is owned
-        by the segment generator.
+        Downloads the frame once, draws the timestamp, and writes the result to a
+        local temp file under ``self.wm_dir`` — it does NOT upload back to GCS.
+        FFmpeg then reads this local file directly, so each frame costs a single
+        GCS download instead of download + re-upload + re-download. The original
+        GCS object is left untouched. The consumer removes the temp via
+        :meth:`cleanup_temp_frames` once the segment is generated.
         """
         import re
 
@@ -228,78 +219,47 @@ class WatermarkService:
         if file_data is None:
             raise FileNotFoundError(f"Frame not found in storage: {gcs_path}")
 
-        # Initialize path variables for cleanup
         tmp_in_path: Path | None = None
-        tmp_out_path: Path | None = None
+        out_path = self.wm_dir / f"wm_{uuid.uuid4().hex}.jpg"
 
         try:
-            # Create temp input file for Pillow processing
             with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_in:
                 tmp_in.write(file_data)
                 tmp_in_path = Path(tmp_in.name)
 
-            # Create a temporary file for the watermarked output
-            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_out:
-                tmp_out_path = Path(tmp_out.name)
-
-            # Apply watermark to the temporary file
             with Image.open(tmp_in_path) as image:
-                # Create drawing context
-                draw = ImageDraw.Draw(image, mode="RGBA")
+                self._draw_watermark(image, timestamp)
+                image.save(out_path, quality=95)
 
-                # Get font
-                font = self._get_font(self.config.font_size)
-
-                # Format timestamp text
-                text = self._format_timestamp(timestamp)
-
-                # Get text bounding box
-                text_bbox = draw.textbbox((0, 0), text, font=font)
-                text_width = text_bbox[2] - text_bbox[0]
-                text_height = text_bbox[3] - text_bbox[1]
-
-                # Calculate position
-                x, y = self._get_position(image.width, image.height, text_bbox)
-
-                # Draw semi-transparent background
-                bg_padding = 5
-                bg_rect = [
-                    x - bg_padding,
-                    y - bg_padding,
-                    x + text_width + bg_padding,
-                    y + text_height + bg_padding,
-                ]
-                draw.rectangle(bg_rect, fill=(0, 0, 0, 204))  # 80% opacity black
-
-                # Draw white text
-                draw.text((x, y), text, fill=(255, 255, 255, 255), font=font)
-
-                # Save to temp output file
-                image.save(tmp_out_path, quality=95)
-
-            # Upload watermarked frame back to GCS (replacing original)
-            with open(tmp_out_path, "rb") as f:
-                watermarked_data = f.read()
-
-            self.storage.write_file(
-                client_id, device_id, subpath, watermarked_data, content_type="image/jpeg"
-            )
-            logger.debug(f"Watermarked frame uploaded to GCS: {gcs_path}")
-
-            # Return the original GCS URI — the object now contains the watermarked
-            # bytes, so downstream can treat it like any other GCS frame. Local temp
-            # files are cleaned in the finally block.
-            return gcs_path
+            logger.debug(f"Watermarked frame written locally: {out_path} (from {gcs_path})")
+            return str(out_path)
 
         finally:
-            # Always clean up both temp files to avoid leaking /tmp/*.jpg
+            # Clean up only the downloaded input; the watermarked output is the
+            # return value and is cleaned by the consumer after segment generation.
             if tmp_in_path and tmp_in_path.exists():
                 try:
                     tmp_in_path.unlink()
                 except OSError:
                     pass
-            if tmp_out_path and tmp_out_path.exists():
-                try:
-                    tmp_out_path.unlink()
-                except OSError:
-                    pass
+
+    def _draw_watermark(self, image: Image.Image, timestamp: datetime) -> None:
+        """Draw the timestamp overlay onto an open PIL image (in place)."""
+        draw = ImageDraw.Draw(image, mode="RGBA")
+        font = self._get_font(self.config.font_size)
+        text = self._format_timestamp(timestamp)
+
+        text_bbox = draw.textbbox((0, 0), text, font=font)
+        text_width = text_bbox[2] - text_bbox[0]
+        text_height = text_bbox[3] - text_bbox[1]
+        x, y = self._get_position(image.width, image.height, text_bbox)
+
+        bg_padding = 5
+        bg_rect = [
+            x - bg_padding,
+            y - bg_padding,
+            x + text_width + bg_padding,
+            y + text_height + bg_padding,
+        ]
+        draw.rectangle(bg_rect, fill=(0, 0, 0, 204))  # 80% opacity black
+        draw.text((x, y), text, fill=(255, 255, 255, 255), font=font)

--- a/tests/test_watermark_service.py
+++ b/tests/test_watermark_service.py
@@ -1,0 +1,59 @@
+"""Tests for WatermarkService local-temp GCS path (no re-upload). Pillow only — CI-safe."""
+
+import io
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+import stream_processor.service.watermark_service as wm
+from stream_processor.config.settings import WatermarkConfig
+
+
+def _jpeg_bytes(w=64, h=48):
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), "gray").save(buf, "JPEG")
+    return buf.getvalue()
+
+
+def _service(monkeypatch):
+    storage = MagicMock()
+    # Avoid building a real (mkdir-ing) storage backend.
+    monkeypatch.setattr(wm, "create_storage_backend", lambda **kw: storage)
+    svc = wm.WatermarkService(WatermarkConfig(enabled=True))
+    return svc, storage
+
+
+class TestWatermarkGcsLocalTemp:
+    def test_writes_local_temp_and_does_not_upload(self, monkeypatch):
+        svc, storage = _service(monkeypatch)
+        storage.read_file.return_value = _jpeg_bytes()
+
+        path = svc._add_watermark_gcs(
+            "gs://bucket/client_ids/c/device_id/d/frames/x.jpg",
+            datetime(2026, 6, 6, 21, 0, 0, tzinfo=UTC),
+        )
+        try:
+            # Returns a local temp under wm_dir — not the gs:// URI.
+            assert svc.is_watermark_temp(path)
+            assert Path(path).exists()
+            with Image.open(path) as im:
+                assert im.size == (64, 48)  # original frame untouched in size
+            # The original GCS object is NOT overwritten.
+            storage.write_file.assert_not_called()
+        finally:
+            svc.cleanup_temp_frames([path])
+
+        # cleanup removed the temp.
+        assert not Path(path).exists()
+
+    def test_is_watermark_temp_excludes_originals(self, monkeypatch):
+        svc, _ = _service(monkeypatch)
+        assert svc.is_watermark_temp("gs://bucket/client_ids/c/device_id/d/frames/x.jpg") is False
+        assert svc.is_watermark_temp("/storage/streams/c/d/frames/x.jpg") is False
+
+    def test_cleanup_ignores_non_temp_paths(self, monkeypatch):
+        svc, _ = _service(monkeypatch)
+        # Must not raise or attempt to delete originals / GCS URIs.
+        svc.cleanup_temp_frames(["gs://b/x.jpg", "/some/original/frame.jpg"])


### PR DESCRIPTION
Closes #26

## Problem
With watermarking on + GCS, each frame cost **~3 GCS ops**: download → draw → **re-upload** (overwriting the original), then the encoder **downloaded it again**. This per-frame GCS cost is the dominant per-device bottleneck (FFmpeg concurrency ~1.0 even in-cluster) and it mutated the original frames.

## Fix
`_add_watermark_gcs` writes the watermarked image to a **local temp** (`wm_dir`) and returns that path — **no upload**. FFmpeg reads it directly → **1 GCS download/frame**. The consumer removes the temps after segment generation (`cleanup_temp_frames`, finally block). Originals are left untouched.

- **Timestamp unchanged**: `request_timestamp` ("the moment we received the frame"); no fallback to the unreliable capture time (per product decision).
- **Rendering unchanged**: same Pillow draw, extracted to `_draw_watermark` and shared with the filesystem path — no visual change.

## Why not a pure FFmpeg filter
A `drawtext` time-expression can't show accurate per-frame request timestamps (frames display 1s apart but are captured ~5s apart), and burned ASS subtitles have font-sizing pitfalls that need visual review. This captures the GCS win safely with identical output; a full in-filter move can follow if warranted.

## Testing
ruff/black/mypy clean; 58 tests pass (+3, Pillow-only/GCS-mocked → CI-safe): returns a local temp, performs no upload, cleanup removes temps and ignores originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured temporary watermarked frame files are always properly cleaned up, even when processing encounters errors.

* **New Features**
  * Watermarked content from cloud storage now remains unmodified; watermarked output is saved to a local temporary location instead.
  * Added utilities for identifying and managing temporary watermarked files.

* **Tests**
  * Added comprehensive tests for watermark processing behavior with cloud storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->