### PR TITLE
fix: recording time range uses capture time, not processing time

### DIFF
--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -253,7 +253,15 @@ class StreamProcessorConsumer:
         """
         if not self.session_store:
             return
-        session_data = await self.session_store.update_activity(state.client_id, state.device_id)
+        # Pass the first pending frame's capture time (request timestamp — "when we
+        # received it"; falls back to its capture timestamp) so the recording's
+        # time range reflects when frames were captured, not when we processed them.
+        frame_time = (
+            state.pending_request_times[0] if state.pending_request_times else None
+        ) or state.pending_first_frame_time
+        session_data = await self.session_store.update_activity(
+            state.client_id, state.device_id, frame_time=frame_time
+        )
         if session_data is not None and session_data.session_id != state.current_session_id:
             if state.current_session_id is not None:
                 logger.info(

--- a/src/stream_processor/service/archive_service.py
+++ b/src/stream_processor/service/archive_service.py
@@ -333,6 +333,8 @@ class ArchiveService:
         """
         pool = await self._get_db_pool()
 
+        # Retention is anchored to WALL-CLOCK time (when archived), not capture
+        # time — otherwise a backlog archive of old footage would expire instantly.
         expires_at = session.last_frame_at + timedelta(days=self.config.retention_days)
 
         await pool.execute(
@@ -348,9 +350,11 @@ class ArchiveService:
             session.device_id,
             session.session_id,
             session.client_id,  # owner_client_id = client_id (device is directly connected)
-            session.started_at,
-            session.last_frame_at,
-            session.duration_seconds,
+            # Displayed time range uses CAPTURE time so backlog recordings show
+            # the real capture window, not the processing window.
+            session.display_started_at,
+            session.display_ended_at,
+            session.captured_duration_seconds,
             session.first_segment_number,
             session.last_segment_number,
             session.segment_count,
@@ -384,9 +388,9 @@ class ArchiveService:
                 session.device_id,
                 session.session_id,
                 session.client_id,  # owner_client_id = client_id (device is directly connected)
-                session.started_at,
-                session.last_frame_at,
-                session.duration_seconds,
+                session.display_started_at,
+                session.display_ended_at,
+                session.captured_duration_seconds,
                 session.first_segment_number,
                 session.last_segment_number,
                 session.segment_count,
@@ -410,13 +414,11 @@ class ArchiveService:
             return 0
 
         # Find expired archives
-        rows = await pool.fetch(
-            """
+        rows = await pool.fetch("""
             SELECT id, client_id, device_id, session_id, archive_path
             FROM deferred_transmissions
             WHERE status = 'ready' AND expires_at < CURRENT_TIMESTAMP
-            """
-        )
+            """)
 
         deleted_count = 0
 

--- a/src/stream_processor/service/offline_checker.py
+++ b/src/stream_processor/service/offline_checker.py
@@ -149,6 +149,8 @@ class OfflineChecker:
             first_segment_number=session.first_segment_number,
             last_segment_number=session.last_segment_number,
             frame_count=session.frame_count,
+            captured_started_at=session.captured_started_dt,
+            captured_ended_at=session.captured_ended_dt,
         )
 
         # Create archive
@@ -231,6 +233,8 @@ class OfflineChecker:
             first_segment_number=session.first_segment_number,
             last_segment_number=session.last_segment_number,
             frame_count=session.frame_count,
+            captured_started_at=session.captured_started_dt,
+            captured_ended_at=session.captured_ended_dt,
         )
 
         # Archive first, then restart

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -9,7 +9,7 @@ Used by:
 
 import json
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime
 from typing import cast
 
@@ -36,11 +36,16 @@ class SessionData:
     client_id: str
     device_id: str
     session_id: str
-    started_at: str  # ISO format
-    last_frame_at: str  # ISO format
+    started_at: str  # ISO format — WALL-CLOCK (offline detection, retention)
+    last_frame_at: str  # ISO format — WALL-CLOCK (offline detection, retention)
     first_segment_number: int
     last_segment_number: int
     frame_count: int
+    # Capture-time bounds (the frame's request timestamp — "when we received it").
+    # Used for the recording's displayed time range so backlog archives show the
+    # real capture window, not the processing window. Optional for back-compat.
+    first_frame_captured_at: str | None = None
+    last_frame_captured_at: str | None = None
 
     @property
     def state_key(self) -> str:
@@ -59,8 +64,27 @@ class SessionData:
 
     @property
     def duration_seconds(self) -> int:
-        """Get the session duration in seconds."""
+        """Get the session duration in seconds (wall-clock)."""
         return int((self.last_frame_at_dt - self.started_at_dt).total_seconds())
+
+    @property
+    def captured_started_dt(self) -> datetime:
+        """Capture time of the first frame (falls back to wall-clock start)."""
+        if self.first_frame_captured_at:
+            return datetime.fromisoformat(self.first_frame_captured_at)
+        return self.started_at_dt
+
+    @property
+    def captured_ended_dt(self) -> datetime:
+        """Capture time of the last frame (falls back to wall-clock end)."""
+        if self.last_frame_captured_at:
+            return datetime.fromisoformat(self.last_frame_captured_at)
+        return self.last_frame_at_dt
+
+    @property
+    def captured_duration_seconds(self) -> int:
+        """Real captured span in seconds (independent of processing/backlog delay)."""
+        return int((self.captured_ended_dt - self.captured_started_dt).total_seconds())
 
     @property
     def segment_count(self) -> int:
@@ -75,8 +99,10 @@ class SessionData:
 
     @classmethod
     def from_json(cls, data: str) -> "SessionData":
-        """Deserialize from JSON."""
-        return cls(**json.loads(data))
+        """Deserialize from JSON, ignoring unknown keys (forward/back compatible)."""
+        raw = json.loads(data)
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in raw.items() if k in known})
 
 
 class RedisSessionStore:
@@ -125,6 +151,7 @@ class RedisSessionStore:
         client_id: str,
         device_id: str,
         expected_session_id: str | None = None,
+        frame_time: datetime | None = None,
     ) -> SessionData | None:
         """
         Update session activity timestamp using optimistic locking.
@@ -154,6 +181,7 @@ class RedisSessionStore:
                 await client.watch(key)
 
                 now = datetime.now(UTC).isoformat()
+                captured = frame_time.isoformat() if frame_time is not None else None
                 existing = await client.get(key)
 
                 if existing:
@@ -172,6 +200,10 @@ class RedisSessionStore:
                         return None
 
                     session.last_frame_at = now
+                    if captured is not None:
+                        if session.first_frame_captured_at is None:
+                            session.first_frame_captured_at = captured
+                        session.last_frame_captured_at = captured
                     session.frame_count += 1
                     is_new_session = False
                 else:
@@ -185,6 +217,8 @@ class RedisSessionStore:
                         first_segment_number=-1,
                         last_segment_number=-1,
                         frame_count=1,
+                        first_frame_captured_at=captured,
+                        last_frame_captured_at=captured,
                     )
                     is_new_session = True
 

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -146,6 +146,48 @@ class RedisSessionStore:
         """Get Redis key for a session."""
         return f"{SESSION_KEY_PREFIX}{client_id}:{device_id}"
 
+    @staticmethod
+    def _resolve_activity(
+        existing_json: str | None,
+        client_id: str,
+        device_id: str,
+        now: str,
+        captured: str | None,
+        expected_session_id: str | None,
+    ) -> tuple[SessionData, bool] | None:
+        """
+        Build the updated-or-new session for an activity tick.
+
+        Returns ``(session, is_new)``, or ``None`` when the update is stale (the
+        stored session_id no longer matches ``expected_session_id``). ``now`` is
+        wall-clock (offline detection); ``captured`` is the frame's capture time.
+        """
+        if existing_json:
+            session = SessionData.from_json(existing_json)
+            if expected_session_id is not None and session.session_id != expected_session_id:
+                return None
+            session.last_frame_at = now
+            if captured is not None:
+                if session.first_frame_captured_at is None:
+                    session.first_frame_captured_at = captured
+                session.last_frame_captured_at = captured
+            session.frame_count += 1
+            return session, False
+
+        new_session = SessionData(
+            client_id=client_id,
+            device_id=device_id,
+            session_id=str(uuid.uuid4()),
+            started_at=now,
+            last_frame_at=now,
+            first_segment_number=-1,
+            last_segment_number=-1,
+            frame_count=1,
+            first_frame_captured_at=captured,
+            last_frame_captured_at=captured,
+        )
+        return new_session, True
+
     async def update_activity(
         self,
         client_id: str,
@@ -184,43 +226,19 @@ class RedisSessionStore:
                 captured = frame_time.isoformat() if frame_time is not None else None
                 existing = await client.get(key)
 
-                if existing:
-                    session = SessionData.from_json(cast(str, existing))
-
-                    # Validate session_id if provided (reject stale updates)
-                    if (
-                        expected_session_id is not None
-                        and session.session_id != expected_session_id
-                    ):
-                        await client.unwatch()
-                        logger.debug(
-                            f"Ignoring stale activity update: {session.state_key} "
-                            f"expected={expected_session_id}, current={session.session_id}"
-                        )
-                        return None
-
-                    session.last_frame_at = now
-                    if captured is not None:
-                        if session.first_frame_captured_at is None:
-                            session.first_frame_captured_at = captured
-                        session.last_frame_captured_at = captured
-                    session.frame_count += 1
-                    is_new_session = False
-                else:
-                    # Create new session
-                    session = SessionData(
-                        client_id=client_id,
-                        device_id=device_id,
-                        session_id=str(uuid.uuid4()),
-                        started_at=now,
-                        last_frame_at=now,
-                        first_segment_number=-1,
-                        last_segment_number=-1,
-                        frame_count=1,
-                        first_frame_captured_at=captured,
-                        last_frame_captured_at=captured,
-                    )
-                    is_new_session = True
+                resolved = self._resolve_activity(
+                    cast("str | None", existing),
+                    client_id,
+                    device_id,
+                    now,
+                    captured,
+                    expected_session_id,
+                )
+                if resolved is None:
+                    await client.unwatch()
+                    logger.debug(f"Ignoring stale activity update for {state_key}")
+                    return None
+                session, is_new_session = resolved
 
                 # Execute atomically
                 async with client.pipeline(transaction=True) as pipe:

--- a/src/stream_processor/service/session_tracker.py
+++ b/src/stream_processor/service/session_tracker.py
@@ -24,11 +24,15 @@ class DeviceSession:
     client_id: str
     device_id: str
     session_id: str
-    started_at: datetime
-    last_frame_at: datetime
+    started_at: datetime  # WALL-CLOCK (offline detection, retention)
+    last_frame_at: datetime  # WALL-CLOCK (offline detection, retention)
     first_segment_number: int
     last_segment_number: int = 0
     frame_count: int = 0
+    # Capture-time bounds for the recording's displayed time range (fall back to
+    # wall-clock when unavailable).
+    captured_started_at: datetime | None = None
+    captured_ended_at: datetime | None = None
 
     @property
     def state_key(self) -> str:
@@ -37,8 +41,23 @@ class DeviceSession:
 
     @property
     def duration_seconds(self) -> int:
-        """Get the session duration in seconds."""
+        """Get the session duration in seconds (wall-clock)."""
         return int((self.last_frame_at - self.started_at).total_seconds())
+
+    @property
+    def display_started_at(self) -> datetime:
+        """Capture-time start for display (falls back to wall-clock)."""
+        return self.captured_started_at or self.started_at
+
+    @property
+    def display_ended_at(self) -> datetime:
+        """Capture-time end for display (falls back to wall-clock)."""
+        return self.captured_ended_at or self.last_frame_at
+
+    @property
+    def captured_duration_seconds(self) -> int:
+        """Real captured span in seconds (falls back to wall-clock duration)."""
+        return int((self.display_ended_at - self.display_started_at).total_seconds())
 
     @property
     def segment_count(self) -> int:

--- a/tests/test_session_data.py
+++ b/tests/test_session_data.py
@@ -1,0 +1,60 @@
+"""Tests for SessionData capture-time bounds (recording time range vs wall-clock)."""
+
+import json
+
+from stream_processor.service.redis_session_store import SessionData
+
+# 17:54 -> 17:57 wall-clock (3 min processing window).
+_BASE = {
+    "client_id": "c",
+    "device_id": "d",
+    "session_id": "s",
+    "started_at": "2026-06-06T17:54:00+00:00",
+    "last_frame_at": "2026-06-06T17:57:00+00:00",
+    "first_segment_number": 0,
+    "last_segment_number": 5,
+    "frame_count": 30,
+}
+
+
+def _sess(**kw):
+    return SessionData(**{**_BASE, **kw})
+
+
+class TestSessionDataCaptureTime:
+    def test_falls_back_to_wallclock_when_no_capture(self):
+        s = _sess()
+        assert s.captured_started_dt == s.started_at_dt
+        assert s.captured_ended_dt == s.last_frame_at_dt
+        assert s.captured_duration_seconds == s.duration_seconds == 180
+
+    def test_uses_capture_times_when_present(self):
+        # Frames captured 11:50 -> 12:05 (15 min) but processed in the 3-min window.
+        s = _sess(
+            first_frame_captured_at="2026-06-06T11:50:00+00:00",
+            last_frame_captured_at="2026-06-06T12:05:00+00:00",
+        )
+        # Display duration reflects the real capture span...
+        assert s.captured_duration_seconds == 15 * 60
+        # ...while wall-clock duration (offline detection / retention) is unchanged.
+        assert s.duration_seconds == 180
+
+    def test_from_json_back_compatible_without_capture_fields(self):
+        old = json.dumps(_BASE)  # no capture fields (old producer)
+        s = SessionData.from_json(old)
+        assert s.first_frame_captured_at is None
+        assert s.captured_duration_seconds == 180  # wall-clock fallback
+
+    def test_from_json_ignores_unknown_keys(self):
+        future = json.dumps({**_BASE, "some_future_field": 123})
+        s = SessionData.from_json(future)
+        assert s.session_id == "s"
+
+    def test_to_json_round_trip_preserves_capture_fields(self):
+        s = _sess(
+            first_frame_captured_at="2026-06-06T11:50:00+00:00",
+            last_frame_captured_at="2026-06-06T12:05:00+00:00",
+        )
+        back = SessionData.from_json(s.to_json())
+        assert back.first_frame_captured_at == "2026-06-06T11:50:00+00:00"
+        assert back.captured_duration_seconds == 15 * 60


### PR DESCRIPTION
Closes #30

## Problem
A backlog recording showed **Capturado 2m57s ≈ Reproducción 2m41s (1×)** instead of ~6×. Root cause: `SessionData` start/end use `datetime.now()` (**processing** time). For backlog frames (captured ~11:50, processed ~17:54 — the watermark proves the gap), the recording displays the processing window, not the capture window. The segments/watermarks were verified correct — only the **metadata** is affected, and only during backlog drain.

## Fix
Add **capture-time bounds** to the session and use them for the recording's displayed start/end/duration; keep **wall-clock** for offline detection and retention/expiry.

| Field | Time base | Used for |
|---|---|---|
| `last_frame_at` / `started_at` | wall-clock | offline detection, expiry |
| `first/last_frame_captured_at` (new) | capture (request_timestamp) | recording start/end/duration |

- `SessionData`: new optional capture fields + `captured_duration_seconds` (falls back to wall-clock); `from_json` ignores unknown keys (rollout-safe).
- `update_activity(frame_time=...)`: populate capture bounds; `last_frame_at` stays wall-clock.
- `DeviceSession` carries the bounds; `_store_archive_metadata`/`_mark_archive_failed` store capture-time `started_at`/`ended_at`/`duration_seconds`; **`expires_at` stays wall-clock** (backlog archives must not expire instantly).
- Consumer passes the first pending frame's capture time per segment.

## Testing
ruff/black/mypy clean; 65 tests pass (+5): capture-duration vs wall-clock, fallback when absent, and back/forward-compatible deserialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session tracking with separate capture-time metrics alongside wall-clock timing.
  * Added captured duration calculation distinct from session duration.

* **Bug Fixes**
  * Fixed archive retention expiry timing to anchor to archive creation time instead of capture time.

* **Tests**
  * Added test coverage for capture-time bounds validation and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->