### PR TITLE
fix: prevent consumer stall on dead Redis connections

### DIFF
--- a/src/stream_processor/config/settings.py
+++ b/src/stream_processor/config/settings.py
@@ -122,6 +122,25 @@ class RedisConfig(BaseSettings):
             "in-memory and seeded from storage on startup."
         ),
     )
+    socket_timeout_seconds: float = Field(
+        default=10.0,
+        description=(
+            "Max seconds a Redis command may block on the socket before raising "
+            "TimeoutError. Without this, a command on a half-dead connection "
+            "(e.g. the Redis pod was rescheduled and the old peer IP black-holes "
+            "traffic) blocks forever and stalls every device worker."
+        ),
+    )
+    socket_connect_timeout_seconds: float = Field(
+        default=5.0, description="Max seconds to wait when establishing a Redis connection"
+    )
+    health_check_interval_seconds: int = Field(
+        default=30,
+        description=(
+            "PING connections idle for this many seconds before reuse, so dead "
+            "pooled connections are detected and replaced instead of handed out"
+        ),
+    )
 
 
 class MetricsConfig(BaseSettings):

--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -195,10 +195,29 @@ class StreamProcessorConsumer:
             while not shutting_down:
                 shutting_down = await self._consume_one(state, queue, interval)
                 if state.should_generate_segment(frames_per_segment, max_wait_seconds=max_wait):
-                    await self._generate_segment(state)
+                    try:
+                        await self._generate_segment(state)
+                    except Exception as e:
+                        # A worker that dies leaves its queue registered but
+                        # undrained, which eventually blocks _dispatch and stalls
+                        # the whole consumer — so no failure here may be fatal.
+                        # Pending frames stay in state and generation is retried
+                        # on the next tick.
+                        processing_errors_total.labels(
+                            device_id=state_key, error_type="generate"
+                        ).inc()
+                        logger.error(
+                            f"Segment generation failed for {state_key}; "
+                            f"retrying next tick: {e}",
+                            exc_info=True,
+                        )
         finally:
             # Flush remaining frames so a graceful stop doesn't drop a partial segment.
             await self._flush_pending_frames(state)
+            # Unregister so a later frame recreates the worker if this exit was
+            # not a graceful shutdown (e.g. cancellation or a non-Exception error).
+            self.device_queues.pop(state_key, None)
+            self.device_workers.pop(state_key, None)
 
     async def _consume_one(self, state: DeviceState, queue: asyncio.Queue, interval: int) -> bool:
         """

--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -207,8 +207,7 @@ class StreamProcessorConsumer:
                             device_id=state_key, error_type="generate"
                         ).inc()
                         logger.error(
-                            f"Segment generation failed for {state_key}; "
-                            f"retrying next tick: {e}",
+                            f"Segment generation failed for {state_key}; retrying next tick: {e}",
                             exc_info=True,
                         )
         finally:

--- a/src/stream_processor/consumer/pulsar_consumer.py
+++ b/src/stream_processor/consumer/pulsar_consumer.py
@@ -217,6 +217,10 @@ class StreamProcessorConsumer:
             # not a graceful shutdown (e.g. cancellation or a non-Exception error).
             self.device_queues.pop(state_key, None)
             self.device_workers.pop(state_key, None)
+            # Keep the gauge balanced: recreation runs _init_device_state again,
+            # which re-registers the state and increments the gauge.
+            if self.device_states.pop(state_key, None) is not None:
+                active_devices_gauge.dec()
 
     async def _consume_one(self, state: DeviceState, queue: asyncio.Queue, interval: int) -> bool:
         """
@@ -385,8 +389,17 @@ class StreamProcessorConsumer:
         )
 
         # Refresh session first — a session boundary resets the PTS offset, which
-        # we snapshot below for this segment.
-        await self._update_session(state)
+        # we snapshot below for this segment. Session tracking is auxiliary
+        # (offline detection, PTS session boundaries), so a Redis failure here
+        # must not abort generation: aborting would keep pending_frames pinned
+        # while new frames accumulate unbounded during a persistent outage,
+        # even though the segment itself only needs GCS. The next successful
+        # refresh re-syncs the session.
+        try:
+            await self._update_session(state)
+        except Exception as e:
+            processing_errors_total.labels(device_id=state_key, error_type="session").inc()
+            logger.warning(f"Session refresh failed for {state_key}; generating anyway: {e}")
 
         segment_number = await self._next_segment_number(state)
         logger.info(f"Generating segment {segment_number} for {state_key} ({len(frames)} frames)")

--- a/src/stream_processor/service/redis_playlist_store.py
+++ b/src/stream_processor/service/redis_playlist_store.py
@@ -60,7 +60,13 @@ class RedisPlaylistStore:
     async def connect(self) -> redis.Redis:
         """Connect to Redis and return the client."""
         if self._client is None:
-            self._client = redis.from_url(self.redis_url, decode_responses=True)
+            self._client = redis.from_url(
+                self.redis_url,
+                decode_responses=True,
+                socket_timeout=settings.redis.socket_timeout_seconds,
+                socket_connect_timeout=settings.redis.socket_connect_timeout_seconds,
+                health_check_interval=settings.redis.health_check_interval_seconds,
+            )
             # Test connection
             await self._client.ping()  # type: ignore[misc]
             logger.info(f"Playlist store connected to Redis at {self._redact_url(self.redis_url)}")

--- a/src/stream_processor/service/redis_session_store.py
+++ b/src/stream_processor/service/redis_session_store.py
@@ -129,7 +129,13 @@ class RedisSessionStore:
     async def connect(self) -> redis.Redis:
         """Connect to Redis and return the client."""
         if self._client is None:
-            self._client = redis.from_url(self.redis_url, decode_responses=True)
+            self._client = redis.from_url(
+                self.redis_url,
+                decode_responses=True,
+                socket_timeout=settings.redis.socket_timeout_seconds,
+                socket_connect_timeout=settings.redis.socket_connect_timeout_seconds,
+                health_check_interval=settings.redis.health_check_interval_seconds,
+            )
             # Test connection
             await self._client.ping()  # type: ignore[misc]
             logger.info(f"Connected to Redis at {self.redis_url}")

--- a/tests/test_consumer_workers.py
+++ b/tests/test_consumer_workers.py
@@ -7,7 +7,7 @@ graceful-shutdown path used in production.
 
 import json
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pulsar
 
@@ -93,9 +93,44 @@ class TestPerDeviceWorker:
 
             await consumer._shutdown_workers()
 
-            assert len(consumer.device_states) == 2
+            # Workers deregister their state on exit so a stale registry can
+            # never accumulate across worker restarts.
+            assert len(consumer.device_states) == 0
             by_device = dict(calls)
             assert by_device == {"a": 0, "b": 0}
+        finally:
+            _shutdown_executors(consumer)
+
+    async def test_session_store_failure_does_not_block_generation(self, monkeypatch):
+        """A dead session store (e.g. Redis outage) must not abort generation.
+
+        If the session refresh aborted the segment, pending frames would stay
+        pinned and grow unbounded for as long as the outage lasts.
+        """
+        calls: list[tuple] = []
+
+        def gen(client_id, device_id, frames, segment_number, offset):
+            calls.append((device_id, list(frames), segment_number))
+            return (f"seg_{segment_number:06d}.ts", float(len(frames)))
+
+        consumer, _ = _make_consumer(monkeypatch, gen)
+        consumer.session_store = MagicMock()
+        consumer.session_store.update_activity = AsyncMock(
+            side_effect=ConnectionError("redis is down")
+        )
+        consumer.session_store.update_segment = AsyncMock(
+            side_effect=ConnectionError("redis is down")
+        )
+        try:
+            fps = consumer.processing_config.frames_per_segment
+            queue = consumer._get_or_create_worker("c:d", "c", "d")
+            for i in range(fps):
+                await queue.put(_make_event("c", "d", i))
+
+            await consumer._shutdown_workers()
+
+            assert len(calls) == 1
+            assert calls[0][2] == 0
         finally:
             _shutdown_executors(consumer)
 


### PR DESCRIPTION
## Incident

On **2026-06-30 14:13 UTC**, GKE maintenance replaced `prod-streamhub-n8n-redis-master-0` ~7 minutes after the stream-processor pod had started. The processor's pooled TCP connections to the old Redis pod IP became black holes (no RST — the peer just vanished).

Because the Redis clients were created with `redis.from_url(url, decode_responses=True)` and **no socket timeout**, every device worker eventually hung forever on an `await` to Redis (session update / playlist add) right after generating a segment. By 14:29 all workers were hung, device queues filled, `_dispatch` blocked on `queue.put`, and Pulsar consumption stopped entirely (`availablePermits=0`) — **with zero errors logged**. The pod stayed "healthy" (metrics port answering), so nothing restarted it.

Result: live view down fleet-wide for ~2 days, a 381k-message backlog on `persistent://streamhub/tracking/frames`, and stale playlists whose segments had all been deleted by the 24h retention cleanup (playlist served fine, every segment 404'd).

## Fix — three defenses

1. **Fail-fast Redis clients** (`redis_playlist_store.py`, `redis_session_store.py`): set `socket_timeout` (10s), `socket_connect_timeout` (5s) and `health_check_interval` (30s), all tunable via `REDIS_SOCKET_TIMEOUT_SECONDS` / `REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS` / `REDIS_HEALTH_CHECK_INTERVAL_SECONDS`. A command on a dead connection now raises `TimeoutError` instead of blocking forever, and idle pooled connections are PINGed before reuse. redis-py's default retry then reconnects on the next call.

2. **Workers survive any generation failure** (`pulsar_consumer.py`): `_device_worker` now catches exceptions from `_generate_segment` per iteration — pending frames are kept in state and generation retries on the next tick. Previously an exception escaping `_update_session` (line 371, outside `_generate_segment`'s internal try) would have killed the worker while leaving its queue registered, jamming the dispatch loop — i.e. the timeout fix alone would have traded an infinite hang for the same stall via a different path.

3. **Workers deregister on exit**: the worker's `finally` now pops its queue/task registration, so if a worker ever exits non-gracefully (cancellation, non-`Exception` error), the next frame recreates it instead of enqueueing into a dead queue forever. (`_shutdown_workers` snapshots before awaiting, so graceful shutdown is unaffected.)

## Verification

- 65/65 tests pass, ruff + black clean.
- No blocking Redis commands (BLPOP/XREAD/pub-sub) in the codebase, so a socket timeout cannot cut a legitimately long-blocking call.
- Prod was restored on 2026-07-02 16:24 UTC by restarting the deployment; the backlog drained as designed (retention-expired frames skipped, recent frames encoded).

## Follow-up (not in this PR)

Consider a liveness probe tied to consumption progress (restart/alert when `msgRateOut=0` with a growing backlog) so a stalled consumer can never again sit undetected for two days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience so per-device segment generation and session/Redis refresh failures no longer stall processing; errors are recorded and generation continues on subsequent cycles.
  * Enhanced cleanup during shutdown to properly unregister per-device workers/queues and keep worker state consistent.
* **New Features**
  * Added Redis connection timeout and health-check configuration to improve reliability for Redis-backed services.
* **Tests**
  * Updated and added consumer worker tests to verify continued generation during session store failures and correct post-shutdown state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #33
